### PR TITLE
Make WebListener target Net45.

### DIFF
--- a/src/Microsoft.Net.Http.Server/AuthenticationManager.cs
+++ b/src/Microsoft.Net.Http.Server/AuthenticationManager.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Net.Http.Server
     /// </summary>
     public sealed class AuthenticationManager
     {
-#if ASPNET50
-        private static readonly int AuthInfoSize =
-            Marshal.SizeOf(typeof(UnsafeNclNativeMethods.HttpApi.HTTP_SERVER_AUTHENTICATION_INFO));
-#else
+#if ASPNETCORE50
         private static readonly int AuthInfoSize =
             Marshal.SizeOf<UnsafeNclNativeMethods.HttpApi.HTTP_SERVER_AUTHENTICATION_INFO>();
+#else
+        private static readonly int AuthInfoSize =
+            Marshal.SizeOf(typeof(UnsafeNclNativeMethods.HttpApi.HTTP_SERVER_AUTHENTICATION_INFO));
 #endif
 
         private WebListener _server;
@@ -163,7 +163,7 @@ namespace Microsoft.Net.Http.Server
                 && requestInfo->InfoType == UnsafeNclNativeMethods.HttpApi.HTTP_REQUEST_INFO_TYPE.HttpRequestInfoTypeAuth
                 && requestInfo->pInfo->AuthStatus == UnsafeNclNativeMethods.HttpApi.HTTP_AUTH_STATUS.HttpAuthStatusSuccess)
             {
-#if ASPNET50
+#if !ASPNETCORE50
                 return true;
 #endif
             }
@@ -176,7 +176,7 @@ namespace Microsoft.Net.Http.Server
                 && requestInfo->InfoType == UnsafeNclNativeMethods.HttpApi.HTTP_REQUEST_INFO_TYPE.HttpRequestInfoTypeAuth
                 && requestInfo->pInfo->AuthStatus == UnsafeNclNativeMethods.HttpApi.HTTP_AUTH_STATUS.HttpAuthStatusSuccess)
             {
-#if ASPNET50
+#if !ASPNETCORE50
                 return new WindowsPrincipal(new WindowsIdentity(requestInfo->pInfo->AccessToken,
                     GetAuthTypeFromRequest(requestInfo->pInfo->AuthType).ToString()));
 #endif

--- a/src/Microsoft.Net.Http.Server/NativeInterop/ComNetOS.cs
+++ b/src/Microsoft.Net.Http.Server/NativeInterop/ComNetOS.cs
@@ -32,11 +32,12 @@ namespace Microsoft.Net.Http.Server
 
         static ComNetOS()
         {
-#if ASPNET50
+#if ASPNETCORE50
+            // TODO: SkipIOCPCallbackOnSuccess doesn't work on Win7. Need a way to detect Win7 vs 8+.
+            IsWin8orLater = false;
+#else
             var win8Version = new Version(6, 2);
             IsWin8orLater = (Environment.OSVersion.Version >= win8Version);
-#else
-            IsWin8orLater = true;
 #endif
         }
     }

--- a/src/Microsoft.Net.Http.Server/NativeInterop/HttpSysSettings.cs
+++ b/src/Microsoft.Net.Http.Server/NativeInterop/HttpSysSettings.cs
@@ -26,7 +26,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Security;
-#if ASPNET50
+#if !ASPNETCORE50
 using Microsoft.Win32;
 #endif
 
@@ -34,7 +34,7 @@ namespace Microsoft.Net.Http.Server
 {
     internal static class HttpSysSettings
     {
-#if ASPNET50
+#if !ASPNETCORE50
         private const string HttpSysParametersKey = @"System\CurrentControlSet\Services\HTTP\Parameters";
 #endif
         private const bool EnableNonUtf8Default = true;
@@ -61,7 +61,7 @@ namespace Microsoft.Net.Http.Server
         }
 
         private static void ReadHttpSysRegistrySettings()
-#if !ASPNET50
+#if ASPNETCORE50
         {
         }
 #else

--- a/src/Microsoft.Net.Http.Server/NativeInterop/NclUtilities.cs
+++ b/src/Microsoft.Net.Http.Server/NativeInterop/NclUtilities.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Net.Http.Server
             get
             {
                 return Environment.HasShutdownStarted
-#if ASPNET50
+#if !ASPNETCORE50
                     || AppDomain.CurrentDomain.IsFinalizingForUnload()
 #endif
                     ;

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/OpaqueStream.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/OpaqueStream.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Net.Http.Server
         {
             return _requestStream.ReadByte();
         }
-#if ASPNET50
+#if !ASPNETCORE50
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {
             return _requestStream.BeginRead(buffer, offset, count, callback, state);
@@ -143,7 +143,7 @@ namespace Microsoft.Net.Http.Server
         {
             _responseStream.WriteByte(value);
         }
-#if ASPNET50
+#if !ASPNETCORE50
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {
             return _responseStream.BeginWrite(buffer, offset, count, callback, state);

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/Request.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/Request.cs
@@ -29,7 +29,7 @@ using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
-#if ASPNET50
+#if !ASPNETCORE50
 using System.Security.Principal;
 #endif
 using System.Threading;

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/RequestStream.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/RequestStream.cs
@@ -198,10 +198,10 @@ namespace Microsoft.Net.Http.Server
             }
         }
 
-#if ASPNET50
-        public override unsafe IAsyncResult BeginRead(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
-#else
+#if ASPNETCORE50
         public unsafe IAsyncResult BeginRead(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
+#else
+        public override unsafe IAsyncResult BeginRead(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
 #endif
         {
             ValidateReadBuffer(buffer, offset, size);
@@ -291,10 +291,10 @@ namespace Microsoft.Net.Http.Server
             return asyncResult;
         }
 
-#if ASPNET50
-        public override int EndRead(IAsyncResult asyncResult)
-#else
+#if ASPNETCORE50
         public int EndRead(IAsyncResult asyncResult)
+#else
+        public override int EndRead(IAsyncResult asyncResult)
 #endif
         {
             if (asyncResult == null)
@@ -425,20 +425,20 @@ namespace Microsoft.Net.Http.Server
         {
             throw new InvalidOperationException(Resources.Exception_ReadOnlyStream);
         }
-        
-#if ASPNET50
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
-#else
+
+#if ASPNETCORE50
         public IAsyncResult BeginWrite(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
+#else
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
 #endif
         {
             throw new InvalidOperationException(Resources.Exception_ReadOnlyStream);
         }
 
-#if ASPNET50
-        public override void EndWrite(IAsyncResult asyncResult)
-#else
+#if ASPNETCORE50
         public void EndWrite(IAsyncResult asyncResult)
+#else
+        public override void EndWrite(IAsyncResult asyncResult)
 #endif
         {
             throw new InvalidOperationException(Resources.Exception_ReadOnlyStream);

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/RequestUriBuilder.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/RequestUriBuilder.cs
@@ -70,10 +70,10 @@ namespace Microsoft.Net.Http.Server
             // TODO: False triggers more detailed/correct parsing, but it's rather slow.
             UseCookedRequestUrl = true; // SettingsSectionInternal.Section.HttpListenerUnescapeRequestUrl;
             Utf8Encoding = new UTF8Encoding(false, true);
-#if ASPNET50
-            AnsiEncoding = Encoding.GetEncoding(0, new EncoderExceptionFallback(), new DecoderExceptionFallback());
-#else
+#if ASPNETCORE50
             AnsiEncoding = Utf8Encoding;
+#else
+            AnsiEncoding = Encoding.GetEncoding(0, new EncoderExceptionFallback(), new DecoderExceptionFallback());
 #endif
         }
 

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/Response.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/Response.cs
@@ -702,10 +702,10 @@ namespace Microsoft.Net.Http.Server
 
                             knownHeaderInfo[_nativeResponse.ResponseInfoCount].Type = UnsafeNclNativeMethods.HttpApi.HTTP_RESPONSE_INFO_TYPE.HttpResponseInfoTypeMultipleKnownHeaders;
                             knownHeaderInfo[_nativeResponse.ResponseInfoCount].Length =
-#if ASPNET50
-                                (uint)Marshal.SizeOf(typeof(UnsafeNclNativeMethods.HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS));
-#else
+#if ASPNETCORE50
                                 (uint)Marshal.SizeOf<UnsafeNclNativeMethods.HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS>();
+#else
+                                (uint)Marshal.SizeOf(typeof(UnsafeNclNativeMethods.HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS));
 #endif
 
                             UnsafeNclNativeMethods.HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS header = new UnsafeNclNativeMethods.HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS();

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/ResponseStream.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/ResponseStream.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Net.Http.Server
             throw new InvalidOperationException(Resources.Exception_WriteOnlyStream);
         }
 
-#if ASPNET50
+#if !ASPNETCORE50
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
         {
             throw new InvalidOperationException(Resources.Exception_WriteOnlyStream);
@@ -360,10 +360,10 @@ namespace Microsoft.Net.Http.Server
 
             // TODO: Verbose log data written
         }
-#if ASPNET50
-        public override unsafe IAsyncResult BeginWrite(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
-#else
+#if ASPNETCORE50
         public unsafe IAsyncResult BeginWrite(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
+#else
+        public override unsafe IAsyncResult BeginWrite(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
 #endif
         {
             if (buffer == null)
@@ -465,10 +465,10 @@ namespace Microsoft.Net.Http.Server
 
             return asyncResult;
         }
-#if ASPNET50
-        public override void EndWrite(IAsyncResult asyncResult)
-#else
+#if ASPNETCORE50
         public void EndWrite(IAsyncResult asyncResult)
+#else
+        public override void EndWrite(IAsyncResult asyncResult)
 #endif
         {
             if (asyncResult == null)

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/ResponseStreamAsyncResult.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/ResponseStreamAsyncResult.cs
@@ -140,12 +140,12 @@ namespace Microsoft.Net.Http.Server
             overlapped.AsyncResult = this;
 
             int bufferSize = 1024 * 64; // TODO: Validate buffer size choice.
-#if ASPNET50
+#if ASPNETCORE50
+            _fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, bufferSize /*, useAsync: true*/); // Extremely expensive.
+#else
             // It's too expensive to validate anything before opening the file. Open the file and then check the lengths.
             _fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, bufferSize,
                     FileOptions.Asynchronous | FileOptions.SequentialScan); // Extremely expensive.
-#else
-            _fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, bufferSize /*, useAsync: true*/); // Extremely expensive.
 #endif
             long length = _fileStream.Length; // Expensive
             if (offset < 0 || offset > length)

--- a/src/Microsoft.Net.Http.Server/TimeoutManager.cs
+++ b/src/Microsoft.Net.Http.Server/TimeoutManager.cs
@@ -35,12 +35,12 @@ namespace Microsoft.Net.Http.Server
     /// </summary>
     public sealed class TimeoutManager
     {
-#if ASPNET50
-        private static readonly int TimeoutLimitSize =
-            Marshal.SizeOf(typeof(UnsafeNclNativeMethods.HttpApi.HTTP_TIMEOUT_LIMIT_INFO));
-#else
+#if ASPNETCORE50
         private static readonly int TimeoutLimitSize =
             Marshal.SizeOf<UnsafeNclNativeMethods.HttpApi.HTTP_TIMEOUT_LIMIT_INFO>();
+#else
+        private static readonly int TimeoutLimitSize =
+            Marshal.SizeOf(typeof(UnsafeNclNativeMethods.HttpApi.HTTP_TIMEOUT_LIMIT_INFO));
 #endif
         private WebListener _server;
         private int[] _timeouts;

--- a/src/Microsoft.Net.Http.Server/WebListener.cs
+++ b/src/Microsoft.Net.Http.Server/WebListener.cs
@@ -44,17 +44,17 @@ namespace Microsoft.Net.Http.Server
     public sealed class WebListener : IDisposable
     {
         private const long DefaultRequestQueueLength = 1000;  // Http.sys default.
-#if ASPNET50
+#if ASPNETCORE50
+        private static readonly int RequestChannelBindStatusSize =
+            Marshal.SizeOf<UnsafeNclNativeMethods.HttpApi.HTTP_REQUEST_CHANNEL_BIND_STATUS>();
+        private static readonly int BindingInfoSize =
+            Marshal.SizeOf<UnsafeNclNativeMethods.HttpApi.HTTP_BINDING_INFO>();
+#else
         private static readonly Type ChannelBindingStatusType = typeof(UnsafeNclNativeMethods.HttpApi.HTTP_REQUEST_CHANNEL_BIND_STATUS);
         private static readonly int RequestChannelBindStatusSize =
             Marshal.SizeOf(typeof(UnsafeNclNativeMethods.HttpApi.HTTP_REQUEST_CHANNEL_BIND_STATUS));
         private static readonly int BindingInfoSize =
             Marshal.SizeOf(typeof(UnsafeNclNativeMethods.HttpApi.HTTP_BINDING_INFO));
-#else
-        private static readonly int RequestChannelBindStatusSize =
-            Marshal.SizeOf<UnsafeNclNativeMethods.HttpApi.HTTP_REQUEST_CHANNEL_BIND_STATUS>();
-        private static readonly int BindingInfoSize =
-            Marshal.SizeOf<UnsafeNclNativeMethods.HttpApi.HTTP_BINDING_INFO>();
 #endif
 
         // Win8# 559317 fixed a bug in Http.sys's HttpReceiveClientCertificate method.
@@ -819,10 +819,10 @@ namespace Microsoft.Net.Http.Server
 
                     knownHeaderInfo[httpResponse.ResponseInfoCount].Type = UnsafeNclNativeMethods.HttpApi.HTTP_RESPONSE_INFO_TYPE.HttpResponseInfoTypeMultipleKnownHeaders;
                     knownHeaderInfo[httpResponse.ResponseInfoCount].Length =
-#if ASPNET50
-                    (uint)Marshal.SizeOf(typeof(UnsafeNclNativeMethods.HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS));
-#else
+#if ASPNETCORE50
                     (uint)Marshal.SizeOf<UnsafeNclNativeMethods.HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS>();
+#else
+                    (uint)Marshal.SizeOf(typeof(UnsafeNclNativeMethods.HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS));
 #endif
 
                     UnsafeNclNativeMethods.HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS header = new UnsafeNclNativeMethods.HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS();
@@ -911,10 +911,10 @@ namespace Microsoft.Net.Http.Server
         private static int GetTokenOffsetFromBlob(IntPtr blob)
         {
             Debug.Assert(blob != IntPtr.Zero);
-#if ASPNET50
-            IntPtr tokenPointer = Marshal.ReadIntPtr(blob, (int)Marshal.OffsetOf(ChannelBindingStatusType, "ChannelToken"));
-#else
+#if ASPNETCORE50
             IntPtr tokenPointer = Marshal.ReadIntPtr(blob, (int)Marshal.OffsetOf<UnsafeNclNativeMethods.HttpApi.HTTP_REQUEST_CHANNEL_BIND_STATUS>("ChannelToken"));
+#else
+            IntPtr tokenPointer = Marshal.ReadIntPtr(blob, (int)Marshal.OffsetOf(ChannelBindingStatusType, "ChannelToken"));
 #endif
             Debug.Assert(tokenPointer != IntPtr.Zero);
             return (int)IntPtrHelper.Subtract(tokenPointer, blob);
@@ -923,10 +923,10 @@ namespace Microsoft.Net.Http.Server
         private static int GetTokenSizeFromBlob(IntPtr blob)
         {
             Debug.Assert(blob != IntPtr.Zero);
-#if ASPNET50
-            return Marshal.ReadInt32(blob, (int)Marshal.OffsetOf(ChannelBindingStatusType, "ChannelTokenSize"));
-#else
+#if ASPNETCORE50
             return Marshal.ReadInt32(blob, (int)Marshal.OffsetOf<UnsafeNclNativeMethods.HttpApi.HTTP_REQUEST_CHANNEL_BIND_STATUS>("ChannelTokenSize"));
+#else
+            return Marshal.ReadInt32(blob, (int)Marshal.OffsetOf(ChannelBindingStatusType, "ChannelTokenSize"));
 #endif
         }
 

--- a/src/Microsoft.Net.Http.Server/WebListenerException.cs
+++ b/src/Microsoft.Net.Http.Server/WebListenerException.cs
@@ -45,12 +45,12 @@ namespace Microsoft.Net.Http.Server
             : base(errorCode, message)
         {
         }
-#if ASPNET50
+#if ASPNETCORE50
+        public int ErrorCode
+#else
         // the base class returns the HResult with this property
         // we need the Win32 Error Code, hence the override.
         public override int ErrorCode
-#else
-        public int ErrorCode
 #endif
         {
             get

--- a/src/Microsoft.Net.Http.Server/fx/Microsoft/Win32/SafeHandles/CriticalHandleZeroOrMinusOneIsInvalid.cs
+++ b/src/Microsoft.Net.Http.Server/fx/Microsoft/Win32/SafeHandles/CriticalHandleZeroOrMinusOneIsInvalid.cs
@@ -21,7 +21,7 @@
 // 
 // ==--==
 
-#if !ASPNET50
+#if ASPNETCORE50
 
 namespace Microsoft.Win32.SafeHandles
 {

--- a/src/Microsoft.Net.Http.Server/fx/Microsoft/Win32/SafeHandles/SafeHandleZeroOrMinusOneIsInvalid.cs
+++ b/src/Microsoft.Net.Http.Server/fx/Microsoft/Win32/SafeHandles/SafeHandleZeroOrMinusOneIsInvalid.cs
@@ -21,7 +21,7 @@
 // 
 // ==--==
 
-#if !ASPNET50
+#if ASPNETCORE50
 
 namespace Microsoft.Win32.SafeHandles
 {

--- a/src/Microsoft.Net.Http.Server/fx/System/Diagnostics/TraceEventType.cs
+++ b/src/Microsoft.Net.Http.Server/fx/System/Diagnostics/TraceEventType.cs
@@ -21,7 +21,7 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-#if !ASPNET50
+#if ASPNETCORE50
 
 using System;
 using System.ComponentModel;

--- a/src/Microsoft.Net.Http.Server/fx/System/ExternDll.cs
+++ b/src/Microsoft.Net.Http.Server/fx/System/ExternDll.cs
@@ -21,17 +21,13 @@
 // </copyright>                                                                
 //------------------------------------------------------------------------------
 
-#if !ASPNET50
+#if ASPNETCORE50
 
 namespace System
 {
     internal static class ExternDll
     {
-#if ASPNETCORE50
         public const string api_ms_win_core_localization_LIB = "api-ms-win-core-localization-l2-1-0.dll";
-#else    
-        public const string Kernel32 = "kernel32.dll";
-#endif
     }
 }
 #endif

--- a/src/Microsoft.Net.Http.Server/fx/System/Runtime/InteropServices/ExternalException.cs
+++ b/src/Microsoft.Net.Http.Server/fx/System/Runtime/InteropServices/ExternalException.cs
@@ -31,7 +31,7 @@
 **
 =============================================================================*/
 
-#if !ASPNET50
+#if ASPNETCORE50
 
 namespace System.Runtime.InteropServices
 {

--- a/src/Microsoft.Net.Http.Server/fx/System/SafeNativeMethods.cs
+++ b/src/Microsoft.Net.Http.Server/fx/System/SafeNativeMethods.cs
@@ -21,7 +21,7 @@
 // </copyright>                                                                
 //------------------------------------------------------------------------------
 
-#if !ASPNET50
+#if ASPNETCORE50
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -36,11 +36,7 @@ namespace System
             FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000,
             FORMAT_MESSAGE_ARGUMENT_ARRAY = 0x00002000;
 
-#if ASPNETCORE50
         [DllImport(ExternDll.api_ms_win_core_localization_LIB, CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true, BestFitMapping = true)]
-#else    
-        [DllImport(ExternDll.Kernel32, CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true, BestFitMapping = true)]
-#endif
         public static unsafe extern int FormatMessage(int dwFlags, IntPtr lpSource_mustBeNull, uint dwMessageId,
                 int dwLanguageId, StringBuilder lpBuffer, int nSize, IntPtr[] arguments);
     }

--- a/src/Microsoft.Net.Http.Server/project.json
+++ b/src/Microsoft.Net.Http.Server/project.json
@@ -8,7 +8,8 @@
     "allowUnsafe": true
   },
   "frameworks": {
-    "aspnet50": {},
+    "net45": { },
+    "aspnet50": { },
     "aspnetcore50": {
       "dependencies": {
         "Microsoft.Net.WebSocketAbstractions": "1.0.0-*",

--- a/src/Microsoft.Net.WebSockets/NativeInterop/SafeNativeOverlapped.cs
+++ b/src/Microsoft.Net.WebSockets/NativeInterop/SafeNativeOverlapped.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Net.WebSockets
             get
             {
                 return Environment.HasShutdownStarted
-#if ASPNET50
+#if !ASPNETCORE50
                     || AppDomain.CurrentDomain.IsFinalizingForUnload()
 #endif
                     ;

--- a/src/Microsoft.Net.WebSockets/NativeInterop/UnsafeNativeMethods.cs
+++ b/src/Microsoft.Net.WebSockets/NativeInterop/UnsafeNativeMethods.cs
@@ -173,10 +173,10 @@ namespace Microsoft.Net.WebSockets
 
             static WebSocketProtocolComponent()
             {
-#if ASPNET50
-                DllFileName = Path.Combine(Environment.SystemDirectory, WEBSOCKET);
-#else
+#if ASPNETCORE50
                 DllFileName = Path.Combine(Environment.GetEnvironmentVariable("SYSTEMROOT"), "System32", WEBSOCKET);
+#else
+                DllFileName = Path.Combine(Environment.SystemDirectory, WEBSOCKET);
 #endif
                 WebSocketDllHandle = SafeLoadLibrary.LoadLibraryEx(DllFileName);
 

--- a/src/Microsoft.Net.WebSockets/WebSocketBase.cs
+++ b/src/Microsoft.Net.WebSockets/WebSocketBase.cs
@@ -1103,7 +1103,7 @@ namespace Microsoft.Net.WebSockets
 
             if (thisLockTaken || sessionHandleLockTaken)
             {
-#if ASPNET50
+#if !ASPNETCORE50
                 RuntimeHelpers.PrepareConstrainedRegions();
 #endif
                 try
@@ -1189,7 +1189,7 @@ namespace Microsoft.Net.WebSockets
             Contract.Assert(lockObject != null, "'lockObject' MUST NOT be NULL.");
             if (lockTaken)
             {
-#if ASPNET50
+#if !ASPNETCORE50
                 RuntimeHelpers.PrepareConstrainedRegions();
 #endif
                 try
@@ -2253,7 +2253,9 @@ namespace Microsoft.Net.WebSockets
                         "'webSocket.m_KeepAliveTracker' MUST NOT be NULL at this point.");
                     int keepAliveIntervalMilliseconds = (int)_keepAliveInterval.TotalMilliseconds;
                     Contract.Assert(keepAliveIntervalMilliseconds > 0, "'keepAliveIntervalMilliseconds' MUST be POSITIVE.");
-#if ASPNET50
+#if ASPNETCORE50
+                    _keepAliveTimer = new Timer(_keepAliveTimerElapsedCallback, webSocket, keepAliveIntervalMilliseconds, Timeout.Infinite);
+#else
                     if (ExecutionContext.IsFlowSuppressed())
                     {
                         _keepAliveTimer = new Timer(_keepAliveTimerElapsedCallback, webSocket, keepAliveIntervalMilliseconds, Timeout.Infinite);
@@ -2265,8 +2267,6 @@ namespace Microsoft.Net.WebSockets
                             _keepAliveTimer = new Timer(_keepAliveTimerElapsedCallback, webSocket, keepAliveIntervalMilliseconds, Timeout.Infinite);
                         }
                     }
-#else
-                    _keepAliveTimer = new Timer(_keepAliveTimerElapsedCallback, webSocket, keepAliveIntervalMilliseconds, Timeout.Infinite);
 #endif
                 }
 

--- a/src/Microsoft.Net.WebSockets/WebSocketBuffer.cs
+++ b/src/Microsoft.Net.WebSockets/WebSocketBuffer.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Net.WebSockets
         public const int MinSendBufferSize = 16;
         internal const int MinReceiveBufferSize = 256;
         internal const int MaxBufferSize = 64 * 1024;
-#if ASPNET50
-        private static readonly int SizeOfUInt = Marshal.SizeOf(typeof(uint));
-        private static readonly int SizeOfBool = Marshal.SizeOf(typeof(bool));
-#else
+#if ASPNETCORE50
         private static readonly int SizeOfUInt = Marshal.SizeOf<uint>();
         private static readonly int SizeOfBool = Marshal.SizeOf<bool>();
+#else
+        private static readonly int SizeOfUInt = Marshal.SizeOf(typeof(uint));
+        private static readonly int SizeOfBool = Marshal.SizeOf(typeof(bool));
 #endif
         private static readonly int PropertyBufferSize = (2 * SizeOfUInt) + SizeOfBool + IntPtr.Size;
 

--- a/src/Microsoft.Net.WebSockets/WebSocketException.cs
+++ b/src/Microsoft.Net.WebSockets/WebSocketException.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Net.WebSockets
 {
-#if ASPNET50
+#if !ASPNETCORE50
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2237:MarkISerializableTypesWithSerializable")]
 #endif
     internal sealed class WebSocketException : Win32Exception

--- a/src/Microsoft.Net.WebSockets/fx/Microsoft/Win32/SafeHandles/SafeHandleZeroOrMinusOneIsInvalid.cs
+++ b/src/Microsoft.Net.WebSockets/fx/Microsoft/Win32/SafeHandles/SafeHandleZeroOrMinusOneIsInvalid.cs
@@ -21,7 +21,7 @@
 // 
 // ==--==
 
-#if !ASPNET50
+#if ASPNETCORE50
 
 namespace Microsoft.Win32.SafeHandles
 {

--- a/src/Microsoft.Net.WebSockets/fx/System/AccessViolationException.cs
+++ b/src/Microsoft.Net.WebSockets/fx/System/AccessViolationException.cs
@@ -15,7 +15,7 @@
 // See the Apache 2 License for the specific language governing
 // permissions and limitations under the License.
 
-#if !ASPNET50
+#if ASPNETCORE50
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Net.WebSockets/fx/System/ComponentModel/Win32Exception.cs
+++ b/src/Microsoft.Net.WebSockets/fx/System/ComponentModel/Win32Exception.cs
@@ -21,7 +21,7 @@
 // </copyright>                                                                
 //------------------------------------------------------------------------------
 
-#if !ASPNET50
+#if ASPNETCORE50
 
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/Microsoft.Net.WebSockets/fx/System/ExternDll.cs
+++ b/src/Microsoft.Net.WebSockets/fx/System/ExternDll.cs
@@ -21,17 +21,13 @@
 // </copyright>                                                                
 //------------------------------------------------------------------------------
 
-#if !ASPNET50
+#if ASPNETCORE50
 
 namespace System
 {
     internal static class ExternDll
     {
-#if NETFX || ASPNET50
-        public const string Kernel32 = "kernel32.dll";
-#else
         public const string api_ms_win_core_localization_LIB = "api-ms-win-core-localization-l2-1-0.dll";
-#endif
     }
 }
 #endif

--- a/src/Microsoft.Net.WebSockets/fx/System/Runtime/InteropServices/ExternalException.cs
+++ b/src/Microsoft.Net.WebSockets/fx/System/Runtime/InteropServices/ExternalException.cs
@@ -31,7 +31,7 @@
 **
 =============================================================================*/
 
-#if !ASPNET50
+#if ASPNETCORE50
 
 namespace System.Runtime.InteropServices
 {

--- a/src/Microsoft.Net.WebSockets/fx/System/SafeNativeMethods.cs
+++ b/src/Microsoft.Net.WebSockets/fx/System/SafeNativeMethods.cs
@@ -21,7 +21,7 @@
 // </copyright>                                                                
 //------------------------------------------------------------------------------
 
-#if !ASPNET50
+#if ASPNETCORE50
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -36,11 +36,7 @@ namespace System
             FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000,
             FORMAT_MESSAGE_ARGUMENT_ARRAY = 0x00002000;
 
-#if ASPNETCORE50
         [DllImport(ExternDll.api_ms_win_core_localization_LIB, CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true, BestFitMapping = true)]
-#else
-        [DllImport(ExternDll.Kernel32, CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true, BestFitMapping = true)]
-#endif
         public static unsafe extern int FormatMessage(int dwFlags, IntPtr lpSource_mustBeNull, uint dwMessageId,
                 int dwLanguageId, StringBuilder lpBuffer, int nSize, IntPtr[] arguments);
     }

--- a/src/Microsoft.Net.WebSockets/fx/System/SystemException.cs
+++ b/src/Microsoft.Net.WebSockets/fx/System/SystemException.cs
@@ -15,7 +15,7 @@
 // See the Apache 2 License for the specific language governing
 // permissions and limitations under the License.
 
-#if !ASPNET50
+#if ASPNETCORE50
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.Net.WebSockets/project.json
+++ b/src/Microsoft.Net.WebSockets/project.json
@@ -5,7 +5,7 @@
      },
      "compilationOptions" : { "allowUnsafe": true },
      "frameworks": {
-          "aspnet50" : { },
+          "net45" : { },
           "aspnetcore50" : {
                "dependencies": {
                     "Microsoft.Win32.Primitives": "4.0.0.0",

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/RequestBodyTests.cs
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/RequestBodyTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.AspNet.Server.WebListener
                 Assert.Equal("Hello World", response);
             }
         }
-#if ASPNET50
+#if !ASPNETCORE50
         [Fact]
         public async Task RequestBody_ReadBeginEnd_Success()
         {

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/project.json
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/project.json
@@ -1,18 +1,18 @@
 {
-     "commands": {
-          "test": "Xunit.KRunner"
-     },
-     "dependencies": {
-          "Microsoft.Net.Http.Server" : "",
-          "Xunit.KRunner": "1.0.0-*"
-     },
-     "frameworks": {
-        "aspnet50": {
-            "dependencies": {
-                "System.Net.Http": "",
-                "System.Net.Http.WebRequest": "",
-                "System.Runtime": ""
+    "commands": {
+        "test": "Xunit.KRunner"
+    },
+    "dependencies": {
+        "System.Net.Http": "4.0.0.0",
+        "System.Runtime": "4.0.20.0",
+        "Microsoft.Net.Http.Server": "1.0.0-*",
+        "Xunit.KRunner": "1.0.0-*"
+    },
+    "frameworks": {
+        "net45": {
+            dependencies: {
+                "System.Net.Http.WebRequest": ""
             }
         }
-     }
+    }
 }


### PR DESCRIPTION
#69 - The base WebListener package (Microsoft.Net.Http.Server) is not intended to be ASP.NET only. Right now it targets aspnet50. Change this to net45 like the various CLR packages.

The bulk of these changes are updating #if's that were being used for CoreCLR behavior.
