### PR TITLE
Suppress shutdown error logs.

### DIFF
--- a/src/Microsoft.AspNet.Server.WebListener/LogHelper.cs
+++ b/src/Microsoft.AspNet.Server.WebListener/LogHelper.cs
@@ -64,6 +64,11 @@ namespace Microsoft.AspNet.Server.WebListener
             }
         }
 
+        internal static void LogVerbose(ILogger logger, string location, Exception exception)
+        {
+            LogVerbose(logger, location + "; " + exception.ToString());
+        }
+
         internal static void LogException(ILogger logger, string location, Exception exception)
         {
             if (logger == null)

--- a/src/Microsoft.AspNet.Server.WebListener/MessagePump.cs
+++ b/src/Microsoft.AspNet.Server.WebListener/MessagePump.cs
@@ -123,8 +123,15 @@ namespace Microsoft.AspNet.Server.WebListener
                 }
                 catch (Exception exception)
                 {
-                    LogHelper.LogException(_logger, "ListenForNextRequestAsync", exception);
-                    Contract.Assert(!_listener.IsListening);
+                    Contract.Assert(_stopping);
+                    if (_stopping)
+                    {
+                        LogHelper.LogVerbose(_logger, "ListenForNextRequestAsync-Stopping", exception);
+                    }
+                    else
+                    {
+                        LogHelper.LogException(_logger, "ListenForNextRequestAsync", exception);
+                    }
                     return;
                 }
                 try
@@ -197,6 +204,7 @@ namespace Microsoft.AspNet.Server.WebListener
 
         public void Dispose()
         {
+            LogHelper.LogInfo(_logger, "Stop");
             _stopping = true;
             // Wait for active requests to drain
             if (_outstandingRequests > 0)


### PR DESCRIPTION
#76. Some errors during shutdown are expected. Log them as verbose instead of errors.

@Eilon 
