### PR TITLE
Sort out default response modes, allow manual chunking.

### DIFF
--- a/src/Microsoft.Net.Http.Server/Constants.cs
+++ b/src/Microsoft.Net.Http.Server/Constants.cs
@@ -29,6 +29,9 @@ namespace Microsoft.Net.Http.Server
     {
         internal const string HttpScheme = "http";
         internal const string HttpsScheme = "https";
+        internal const string Chunked = "chunked";
+        internal const string Close = "close";
+        internal const string Zero = "0";
         internal const string SchemeDelimiter = "://";
 
         internal static Version V1_0 = new Version(1, 0);

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/BoundaryType.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/BoundaryType.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Net.Http.Server
         None = 0,
         Chunked = 1, // Transfer-Encoding: chunked
         ContentLength = 2, // Content-Length: XXX
-        Invalid = 3,
+        Close = 3, // Connection: close
+        PassThrough = 4, // The application is handling the boundary themselves (e.g. chunking themselves).
+        Invalid = 5,
     }
 }

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/Request.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/Request.cs
@@ -263,6 +263,11 @@ namespace Microsoft.Net.Http.Server
             get { return _httpMethod; }
         }
 
+        public bool IsHeadMethod
+        {
+            get { return string.Equals(_httpMethod, "HEAD", StringComparison.OrdinalIgnoreCase); }
+        }
+
         public Stream Body
         {
             get
@@ -413,7 +418,7 @@ namespace Microsoft.Net.Http.Server
         {
             get
             {
-                return Headers.Get(HttpKnownHeaderNames.ContentLength);
+                return Headers.Get(HttpKnownHeaderNames.ContentType);
             }
         }
 

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/ResponseBodyTests.cs
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/ResponseBodyTests.cs
@@ -99,28 +99,7 @@ namespace Microsoft.AspNet.Server.WebListener
                 Assert.Equal(new byte[30], await response.Content.ReadAsByteArrayAsync());
             }
         }
-        /* TODO: response protocol
-        [Fact]
-        public async Task ResponseBody_Http10WriteNoHeaders_DefaultsConnectionClose()
-        {
-            string address;
-            using (Utilities.CreateHttpServer(out address, env =>
-            {
-                env["owin.ResponseProtocol"] = "HTTP/1.0";
-                env.Get<Stream>("owin.ResponseBody").Write(new byte[10], 0, 10);
-                return env.Get<Stream>("owin.ResponseBody").WriteAsync(new byte[10], 0, 10);
-            }))
-            {
-                HttpResponseMessage response = await SendRequestAsync(address);
-                Assert.Equal(200, (int)response.StatusCode);
-                Assert.Equal(new Version(1, 1), response.Version); // Http.Sys won't transmit 1.0
-                IEnumerable<string> ignored;
-                Assert.False(response.Content.Headers.TryGetValues("content-length", out ignored), "Content-Length");
-                Assert.Null(response.Headers.TransferEncodingChunked);
-                Assert.Equal(new byte[20], await response.Content.ReadAsByteArrayAsync());
-            }
-        }
-        */
+
         [Fact]
         public async Task ResponseBody_WriteContentLengthNoneWritten_Throws()
         {

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/ResponseSendFileTests.cs
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/ResponseSendFileTests.cs
@@ -162,14 +162,13 @@ namespace Microsoft.AspNet.Server.WebListener
         }
 
         [Fact]
-        public async Task ResponseSendFile_Chunked_Chunked()
+        public async Task ResponseSendFile_Unspecified_Chunked()
         {
             string address;
             using (Utilities.CreateHttpServer(out address, env =>
             {
                 var httpContext = new DefaultHttpContext((IFeatureCollection)env);
                 var sendFile = httpContext.GetFeature<IHttpSendFileFeature>();
-                httpContext.Response.Headers["Transfer-EncodinG"] = "CHUNKED";
                 return sendFile.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
             }))
             {
@@ -183,14 +182,13 @@ namespace Microsoft.AspNet.Server.WebListener
         }
 
         [Fact]
-        public async Task ResponseSendFile_MultipleChunks_Chunked()
+        public async Task ResponseSendFile_MultipleWrites_Chunked()
         {
             string address;
             using (Utilities.CreateHttpServer(out address, env =>
             {
                 var httpContext = new DefaultHttpContext((IFeatureCollection)env);
                 var sendFile = httpContext.GetFeature<IHttpSendFileFeature>();
-                httpContext.Response.Headers["Transfer-EncodinG"] = "CHUNKED";
                 sendFile.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None).Wait();
                 return sendFile.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
             }))
@@ -205,7 +203,7 @@ namespace Microsoft.AspNet.Server.WebListener
         }
 
         [Fact]
-        public async Task ResponseSendFile_ChunkedHalfOfFile_Chunked()
+        public async Task ResponseSendFile_HalfOfFile_Chunked()
         {
             string address;
             using (Utilities.CreateHttpServer(out address, env =>
@@ -225,7 +223,7 @@ namespace Microsoft.AspNet.Server.WebListener
         }
 
         [Fact]
-        public async Task ResponseSendFile_ChunkedOffsetOutOfRange_Throws()
+        public async Task ResponseSendFile_OffsetOutOfRange_Throws()
         {
             string address;
             using (Utilities.CreateHttpServer(out address, env =>
@@ -241,7 +239,7 @@ namespace Microsoft.AspNet.Server.WebListener
         }
 
         [Fact]
-        public async Task ResponseSendFile_ChunkedCountOutOfRange_Throws()
+        public async Task ResponseSendFile_CountOutOfRange_Throws()
         {
             string address;
             using (Utilities.CreateHttpServer(out address, env =>
@@ -257,7 +255,7 @@ namespace Microsoft.AspNet.Server.WebListener
         }
 
         [Fact]
-        public async Task ResponseSendFile_ChunkedCount0_Chunked()
+        public async Task ResponseSendFile_Count0_Chunked()
         {
             string address;
             using (Utilities.CreateHttpServer(out address, env =>

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/ResponseSendFileTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/ResponseSendFileTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Net.Http.Server
         }
 
         [Fact]
-        public async Task ResponseSendFile_Chunked_Chunked()
+        public async Task ResponseSendFile_Unspecified_Chunked()
         {
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
@@ -92,7 +92,6 @@ namespace Microsoft.Net.Http.Server
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
                 var context = await server.GetContextAsync();
-                context.Response.Headers["Transfer-EncodinG"] = "CHUNKED";
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
                 context.Dispose();
 
@@ -106,7 +105,7 @@ namespace Microsoft.Net.Http.Server
         }
 
         [Fact]
-        public async Task ResponseSendFile_MultipleChunks_Chunked()
+        public async Task ResponseSendFile_MultipleWrites_Chunked()
         {
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
@@ -114,7 +113,6 @@ namespace Microsoft.Net.Http.Server
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
                 var context = await server.GetContextAsync();
-                context.Response.Headers["Transfer-EncodinG"] = "CHUNKED";
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
                 context.Dispose();
@@ -129,7 +127,7 @@ namespace Microsoft.Net.Http.Server
         }
 
         [Fact]
-        public async Task ResponseSendFile_ChunkedHalfOfFile_Chunked()
+        public async Task ResponseSendFile_HalfOfFile_Chunked()
         {
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
@@ -150,7 +148,7 @@ namespace Microsoft.Net.Http.Server
         }
 
         [Fact]
-        public async Task ResponseSendFile_ChunkedOffsetOutOfRange_Throws()
+        public async Task ResponseSendFile_OffsetOutOfRange_Throws()
         {
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
@@ -167,7 +165,7 @@ namespace Microsoft.Net.Http.Server
         }
 
         [Fact]
-        public async Task ResponseSendFile_ChunkedCountOutOfRange_Throws()
+        public async Task ResponseSendFile_CountOutOfRange_Throws()
         {
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
@@ -184,7 +182,7 @@ namespace Microsoft.Net.Http.Server
         }
 
         [Fact]
-        public async Task ResponseSendFile_ChunkedCount0_Chunked()
+        public async Task ResponseSendFile_Count0_Chunked()
         {
             string address;
             using (var server = Utilities.CreateHttpServer(out address))


### PR DESCRIPTION
#112, #113

Do the same thing as Helios when the user sets response headers (Content-Length, Transfer-Encoding, or Connection). Have consistent defaults when they don't tell us what they want.
- If they set Content-Length, that's what they get
- If they set Transfer-Encoding: chunked, they have to implement the chunking themselves
- If the set Connection: close, close the connection after the request.
- If they don't specify, default to chunked for HTTP/1.1 and close for 1.0 (or Content-Length: 0 if the request is ending without a body).

Clean out things that Http.Sys no longer supports:
- HTTP/1.0 Keep-Alive: true and Connection: Keep-Alive headers.
- Setting the response protocol version to anything but 1.1.

@muratg 
