### PR TITLE
Implement ITlsTokenBindingFeature.

### DIFF
--- a/src/Microsoft.AspNet.Server.WebListener/FeatureContext.cs
+++ b/src/Microsoft.AspNet.Server.WebListener/FeatureContext.cs
@@ -38,6 +38,7 @@ namespace Microsoft.AspNet.Server.WebListener
         IHttpResponseFeature,
         IHttpSendFileFeature,
         ITlsConnectionFeature,
+        ITlsTokenBindingFeature,
         IHttpRequestLifetimeFeature,
         IHttpWebSocketFeature,
         IHttpAuthenticationFeature,
@@ -103,6 +104,7 @@ namespace Microsoft.AspNet.Server.WebListener
             if (Request.IsSecureConnection)
             {
                 _features.Add(typeof(ITlsConnectionFeature), this);
+                _features.Add(typeof(ITlsTokenBindingFeature), this);
             }
 
             // Win8+
@@ -314,6 +316,16 @@ namespace Microsoft.AspNet.Server.WebListener
                 _clientCert = await Request.GetClientCertificateAsync(cancellationToken);
             }
             return _clientCert;
+        }
+
+        byte[] ITlsTokenBindingFeature.GetProvidedTokenBindingId()
+        {
+            return Request.GetProvidedTokenBindingId();
+        }
+
+        byte[] ITlsTokenBindingFeature.GetReferredTokenBindingId()
+        {
+            return Request.GetReferredTokenBindingId();
         }
 
         Stream IHttpResponseFeature.Body

--- a/src/Microsoft.Net.Http.Server/AuthenticationManager.cs
+++ b/src/Microsoft.Net.Http.Server/AuthenticationManager.cs
@@ -167,14 +167,18 @@ namespace Microsoft.Net.Http.Server
             return false;
         }
 
-        internal static unsafe ClaimsPrincipal GetUser(UnsafeNclNativeMethods.HttpApi.HTTP_REQUEST_INFO* requestInfo)
+        internal static unsafe ClaimsPrincipal GetUser(UnsafeNclNativeMethods.HttpApi.HTTP_REQUEST_INFO* requestInfo, int infoCount)
         {
-            if (requestInfo != null
-                && requestInfo->InfoType == UnsafeNclNativeMethods.HttpApi.HTTP_REQUEST_INFO_TYPE.HttpRequestInfoTypeAuth
-                && requestInfo->pInfo->AuthStatus == UnsafeNclNativeMethods.HttpApi.HTTP_AUTH_STATUS.HttpAuthStatusSuccess)
+            for (int i = 0; i < infoCount; i++)
             {
-                return new WindowsPrincipal(new WindowsIdentity(requestInfo->pInfo->AccessToken,
-                    GetAuthTypeFromRequest(requestInfo->pInfo->AuthType).ToString()));
+                var info = &requestInfo[i];
+                if (requestInfo != null
+                    && info->InfoType == UnsafeNclNativeMethods.HttpApi.HTTP_REQUEST_INFO_TYPE.HttpRequestInfoTypeAuth
+                    && info->pInfo->AuthStatus == UnsafeNclNativeMethods.HttpApi.HTTP_AUTH_STATUS.HttpAuthStatusSuccess)
+                {
+                    return new WindowsPrincipal(new WindowsIdentity(info->pInfo->AccessToken,
+                        GetAuthTypeFromRequest(info->pInfo->AuthType).ToString()));
+                }
             }
             return new ClaimsPrincipal(new ClaimsIdentity()); // Anonymous / !IsAuthenticated
         }

--- a/src/Microsoft.Net.Http.Server/NativeInterop/HeapAllocHandle.cs
+++ b/src/Microsoft.Net.Http.Server/NativeInterop/HeapAllocHandle.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation.
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+// WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF
+// TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR
+// NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing
+// permissions and limitations under the License.
+
+using System;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.Net.Http.Server
+{
+    internal sealed class HeapAllocHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        private static readonly IntPtr ProcessHeap = UnsafeNclNativeMethods.GetProcessHeap();
+
+        // Called by P/Invoke when returning SafeHandles
+        private HeapAllocHandle()
+            : base(ownsHandle: true)
+        {
+        }
+
+        // Do not provide a finalizer - SafeHandle's critical finalizer will call ReleaseHandle for you.
+        protected override bool ReleaseHandle()
+        {
+            return UnsafeNclNativeMethods.HeapFree(ProcessHeap, 0, handle);
+        }
+    }
+}

--- a/src/Microsoft.Net.Http.Server/NativeInterop/TokenBindingUtil.cs
+++ b/src/Microsoft.Net.Http.Server/NativeInterop/TokenBindingUtil.cs
@@ -1,0 +1,94 @@
+// Copyright (c) .NET Foundation.
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+// WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF
+// TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR
+// NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing
+// permissions and limitations under the License.
+
+using System;
+using System.Runtime.InteropServices;
+using static Microsoft.Net.Http.Server.UnsafeNclNativeMethods.HttpApi;
+using static Microsoft.Net.Http.Server.UnsafeNclNativeMethods.TokenBinding;
+
+namespace Microsoft.Net.Http.Server
+{
+    /// <summary>
+    /// Contains helpers for dealing with TLS token binding.
+    /// </summary>
+    internal unsafe static class TokenBindingUtil
+    {
+        private static byte[] ExtractIdentifierBlob(TOKENBINDING_RESULT_DATA* pTokenBindingResultData)
+        {
+            // Per http://tools.ietf.org/html/draft-ietf-tokbind-protocol-00, Sec. 4,
+            // the identifer is a tuple which contains (token binding type, hash algorithm
+            // signature algorithm, key data). We'll strip off the token binding type and
+            // return the remainder (starting with the hash algorithm) as an opaque blob.
+            byte[] retVal = new byte[checked(pTokenBindingResultData->identifierSize - 1)];
+            Marshal.Copy((IntPtr)(&pTokenBindingResultData->identifierData->hashAlgorithm), retVal, 0, retVal.Length);
+            return retVal;
+        }
+
+        /// <summary>
+        /// Returns the 'provided' token binding identifier, optionally also returning the
+        /// 'referred' token binding identifier. Returns null on failure.
+        /// </summary>
+        public static byte[] GetProvidedTokenIdFromBindingInfo(HTTP_REQUEST_TOKEN_BINDING_INFO* pTokenBindingInfo, out byte[] referredId)
+        {
+            byte[] providedId = null;
+            referredId = null;
+
+            HeapAllocHandle handle = null;
+            int status = UnsafeNclNativeMethods.TokenBindingVerifyMessage(
+                pTokenBindingInfo->TokenBinding,
+                pTokenBindingInfo->TokenBindingSize,
+                pTokenBindingInfo->KeyType,
+                pTokenBindingInfo->TlsUnique,
+                pTokenBindingInfo->TlsUniqueSize,
+                out handle);
+
+            // No match found or there was an error?
+            if (status != 0 || handle == null || handle.IsInvalid)
+            {
+                return null;
+            }
+
+            using (handle)
+            {
+                // Find the first 'provided' and 'referred' types.
+                TOKENBINDING_RESULT_LIST* pResultList = (TOKENBINDING_RESULT_LIST*)handle.DangerousGetHandle();
+                for (int i = 0; i < pResultList->resultCount; i++)
+                {
+                    TOKENBINDING_RESULT_DATA* pThisResultData = &pResultList->resultData[i];
+                    if (pThisResultData->identifierData->bindingType == TOKENBINDING_TYPE.TOKENBINDING_TYPE_PROVIDED)
+                    {
+                        if (providedId != null)
+                        {
+                            return null; // It is invalid to have more than one 'provided' identifier.
+                        }
+                        providedId = ExtractIdentifierBlob(pThisResultData);
+                    }
+                    else if (pThisResultData->identifierData->bindingType == TOKENBINDING_TYPE.TOKENBINDING_TYPE_REFERRED)
+                    {
+                        if (referredId != null)
+                        {
+                            return null; // It is invalid to have more than one 'referred' identifier.
+                        }
+                        referredId = ExtractIdentifierBlob(pThisResultData);
+                    }
+                }
+            }
+
+            return providedId;
+        }
+    }
+}


### PR DESCRIPTION
#82

I'm copying over this implementation from Helios just to make sure it works. There are no tests because IE is the only client that supports it so far. It also requires Win10 with multiple registry keys enabled.  I did test it manually.

@muratg 
