### PR TITLE
Implement response buffering

### DIFF
--- a/src/Microsoft.AspNet.Server.WebListener/FeatureContext.cs
+++ b/src/Microsoft.AspNet.Server.WebListener/FeatureContext.cs
@@ -39,6 +39,7 @@ namespace Microsoft.AspNet.Server.WebListener
         IHttpSendFileFeature,
         ITlsConnectionFeature,
         ITlsTokenBindingFeature,
+        IHttpBufferingFeature,
         IHttpRequestLifetimeFeature,
         IHttpWebSocketFeature,
         IHttpAuthenticationFeature,
@@ -97,6 +98,7 @@ namespace Microsoft.AspNet.Server.WebListener
             _features.Add(typeof(IHttpConnectionFeature), this);
             _features.Add(typeof(IHttpResponseFeature), this);
             _features.Add(typeof(IHttpSendFileFeature), this);
+            _features.Add(typeof(IHttpBufferingFeature), this);
             _features.Add(typeof(IHttpRequestLifetimeFeature), this);
             _features.Add(typeof(IHttpAuthenticationFeature), this);
             _features.Add(typeof(IRequestIdentifierFeature), this);
@@ -328,6 +330,16 @@ namespace Microsoft.AspNet.Server.WebListener
             return Request.GetReferredTokenBindingId();
         }
 
+        void IHttpBufferingFeature.DisableRequestBuffering()
+        {
+            // There is no request buffering.
+        }
+
+        void IHttpBufferingFeature.DisableResponseBuffering()
+        {
+            Response.ShouldBuffer = false;
+        }
+
         Stream IHttpResponseFeature.Body
         {
             get
@@ -356,7 +368,7 @@ namespace Microsoft.AspNet.Server.WebListener
 
         bool IHttpResponseFeature.HeadersSent
         {
-            get { return Response.HeadersSent; }
+            get { return Response.HasStarted; }
         }
 
         void IHttpResponseFeature.OnSendingHeaders(Action<object> callback, object state)

--- a/src/Microsoft.AspNet.Server.WebListener/MessagePump.cs
+++ b/src/Microsoft.AspNet.Server.WebListener/MessagePump.cs
@@ -167,13 +167,14 @@ namespace Microsoft.AspNet.Server.WebListener
                 catch (Exception ex)
                 {
                     LogHelper.LogException(_logger, "ProcessRequestAsync", ex);
-                    if (requestContext.Response.HeadersSent)
+                    if (requestContext.Response.HasStartedSending)
                     {
                         requestContext.Abort();
                     }
                     else
                     {
                         // We haven't sent a response yet, try to send a 500 Internal Server Error
+                        requestContext.Response.Reset();
                         SetFatalResponse(requestContext, 500);
                     }
                 }
@@ -195,8 +196,6 @@ namespace Microsoft.AspNet.Server.WebListener
         private static void SetFatalResponse(RequestContext context, int status)
         {
             context.Response.StatusCode = status;
-            context.Response.ReasonPhrase = string.Empty;
-            context.Response.Headers.Clear();
             context.Response.ContentLength = 0;
             context.Dispose();
         }

--- a/src/Microsoft.Net.Http.Server/Helpers.cs
+++ b/src/Microsoft.Net.Http.Server/Helpers.cs
@@ -21,13 +21,18 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Net.Http.Server
 {
     internal static class Helpers
     {
+        internal static readonly byte[] ChunkTerminator = new byte[] { (byte)'0', (byte)'\r', (byte)'\n', (byte)'\r', (byte)'\n' };
+        internal static readonly byte[] CRLF = new byte[] { (byte)'\r', (byte)'\n' };
+
         internal static Task CompletedTask()
         {
             return Task.FromResult<object>(null);
@@ -48,6 +53,95 @@ namespace Microsoft.Net.Http.Server
         internal static ConfiguredTaskAwaitable<T> SupressContext<T>(this Task<T> task)
         {
             return task.ConfigureAwait(continueOnCapturedContext: false);
+        }
+
+        internal static IAsyncResult ToIAsyncResult(this Task task, AsyncCallback callback, object state)
+        {
+            var tcs = new TaskCompletionSource<int>(state);
+            task.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    tcs.TrySetException(t.Exception.InnerExceptions);
+                }
+                else if (t.IsCanceled)
+                {
+                    tcs.TrySetCanceled();
+                }
+                else
+                {
+                    tcs.TrySetResult(0);
+                }
+
+                if (callback != null)
+                {
+                    callback(tcs.Task);
+                }
+            }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// A private utility routine to convert an integer to a chunk header,
+        /// which is an ASCII hex number followed by a CRLF.The header is returned
+        /// as a byte array.
+        /// Generates a right-aligned hex string and returns the start offset.
+        /// </summary>
+        /// <param name="size">Chunk size to be encoded</param>
+        /// <param name="offset">Out parameter where we store offset into buffer.</param>
+        /// <returns>A byte array with the header in int.</returns>
+        internal static ArraySegment<byte> GetChunkHeader(int size)
+        {
+            uint mask = 0xf0000000;
+            byte[] header = new byte[10];
+            int i;
+            int offset = -1;
+
+            // Loop through the size, looking at each nibble. If it's not 0
+            // convert it to hex. Save the index of the first non-zero
+            // byte.
+
+            for (i = 0; i < 8; i++, size <<= 4)
+            {
+                // offset == -1 means that we haven't found a non-zero nibble
+                // yet. If we haven't found one, and the current one is zero,
+                // don't do anything.
+
+                if (offset == -1)
+                {
+                    if ((size & mask) == 0)
+                    {
+                        continue;
+                    }
+                }
+
+                // Either we have a non-zero nibble or we're no longer skipping
+                // leading zeros. Convert this nibble to ASCII and save it.
+
+                uint temp = (uint)size >> 28;
+
+                if (temp < 10)
+                {
+                    header[i] = (byte)(temp + '0');
+                }
+                else
+                {
+                    header[i] = (byte)((temp - 10) + 'A');
+                }
+
+                // If we haven't found a non-zero nibble yet, we've found one
+                // now, so remember that.
+
+                if (offset == -1)
+                {
+                    offset = i;
+                }
+            }
+
+            header[8] = (byte)'\r';
+            header[9] = (byte)'\n';
+
+            return new ArraySegment<byte>(header, offset, header.Length - offset);
         }
     }
 }

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/BufferBuilder.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/BufferBuilder.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Net.Http.Server
+{
+    internal class BufferBuilder
+    {
+        private List<ArraySegment<byte>> _buffers = new List<ArraySegment<byte>>();
+
+        internal IEnumerable<ArraySegment<byte>> Buffers
+        {
+            get { return _buffers; }
+        }
+
+        internal int BufferCount
+        {
+            get { return _buffers.Count; }
+        }
+
+        internal int TotalBytes { get; private set; }
+
+        internal void Add(ArraySegment<byte> data)
+        {
+            _buffers.Add(data);
+            TotalBytes += data.Count;
+        }
+
+        public void CopyAndAdd(ArraySegment<byte> data)
+        {
+            if (data.Count > 0)
+            {
+                var temp = new byte[data.Count];
+                Buffer.BlockCopy(data.Array, data.Offset, temp, 0, data.Count);
+                _buffers.Add(new ArraySegment<byte>(temp));
+                TotalBytes += data.Count;
+            }
+        }
+
+        public void Clear()
+        {
+            _buffers.Clear();
+            TotalBytes = 0;
+        }
+    }
+}

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/HeaderCollection.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/HeaderCollection.cs
@@ -21,15 +21,15 @@ namespace Microsoft.Net.Http.Server
 
         private IDictionary<string, string[]> Store { get; set; }
 
-        // Readonly after the response has been sent.
-        internal bool Sent { get; set; }
+        // Readonly after the response has been started.
+        public bool IsReadOnly { get; internal set; }
 
         public string this[string key]
         {
             get { return Get(key); }
             set
             {
-                ThrowIfSent();
+                ThrowIfReadOnly();
                 if (string.IsNullOrEmpty(value))
                 {
                     Remove(key);
@@ -46,7 +46,7 @@ namespace Microsoft.Net.Http.Server
             get { return Store[key]; }
             set
             {
-                ThrowIfSent();
+                ThrowIfReadOnly();
                 Store[key] = value;
             }
         }
@@ -54,11 +54,6 @@ namespace Microsoft.Net.Http.Server
         public int Count
         {
             get { return Store.Count; }
-        }
-
-        public bool IsReadOnly
-        {
-            get { return Sent; }
         }
 
         public ICollection<string> Keys
@@ -73,19 +68,19 @@ namespace Microsoft.Net.Http.Server
 
         public void Add(KeyValuePair<string, string[]> item)
         {
-            ThrowIfSent();
+            ThrowIfReadOnly();
             Store.Add(item);
         }
 
         public void Add(string key, string[] value)
         {
-            ThrowIfSent();
+            ThrowIfReadOnly();
             Store.Add(key, value);
         }
 
         public void Append(string key, string value)
         {
-            ThrowIfSent();
+            ThrowIfReadOnly();
             string[] values;
             if (Store.TryGetValue(key, out values))
             {
@@ -102,7 +97,7 @@ namespace Microsoft.Net.Http.Server
 
         public void AppendValues(string key, params string[] values)
         {
-            ThrowIfSent();
+            ThrowIfReadOnly();
             string[] oldValues;
             if (Store.TryGetValue(key, out oldValues))
             {
@@ -119,7 +114,7 @@ namespace Microsoft.Net.Http.Server
 
         public void Clear()
         {
-            ThrowIfSent();
+            ThrowIfReadOnly();
             Store.Clear();
         }
 
@@ -165,25 +160,25 @@ namespace Microsoft.Net.Http.Server
 
         public bool Remove(KeyValuePair<string, string[]> item)
         {
-            ThrowIfSent();
+            ThrowIfReadOnly();
             return Store.Remove(item);
         }
 
         public bool Remove(string key)
         {
-            ThrowIfSent();
+            ThrowIfReadOnly();
             return Store.Remove(key);
         }
 
         public void Set(string key, string value)
         {
-            ThrowIfSent();
+            ThrowIfReadOnly();
             Store[key] = new[] { value };
         }
 
         public void SetValues(string key, params string[] values)
         {
-            ThrowIfSent();
+            ThrowIfReadOnly();
             Store[key] = values;
         }
 
@@ -197,11 +192,11 @@ namespace Microsoft.Net.Http.Server
             return GetEnumerator();
         }
 
-        private void ThrowIfSent()
+        private void ThrowIfReadOnly()
         {
-            if (Sent)
+            if (IsReadOnly)
             {
-                throw new InvalidOperationException("The response headers cannot be modified because they have already been sent.");
+                throw new InvalidOperationException("The response headers cannot be modified because the response has already started.");
             }
         }
     }

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/RequestContext.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/RequestContext.cs
@@ -158,9 +158,9 @@ namespace Microsoft.Net.Http.Server
 
         public Task<Stream> UpgradeAsync()
         {
-            if (!IsUpgradableRequest || _response.HeadersSent)
+            if (!IsUpgradableRequest || _response.HasStarted)
             {
-                throw new InvalidOperationException();
+                throw new InvalidOperationException("This request cannot be upgraded. It is incompatible, or the response has already started.");
             }
 
             // Set the status code and reason phrase

--- a/src/Microsoft.Net.Http.Server/WebListener.cs
+++ b/src/Microsoft.Net.Http.Server/WebListener.cs
@@ -91,6 +91,8 @@ namespace Microsoft.Net.Http.Server
         // The native request queue
         private long? _requestQueueLength;
 
+        private bool _bufferResponses = true;
+
         public WebListener()
             : this(null)
         {
@@ -132,6 +134,12 @@ namespace Microsoft.Net.Http.Server
         public UrlPrefixCollection UrlPrefixes
         {
             get { return _urlPrefixes; }
+        }
+
+        public bool BufferResponses
+        {
+            get { return _bufferResponses; }
+            set { _bufferResponses = value; }
         }
 
         internal SafeHandle RequestQueueHandle

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/Microsoft.AspNet.Server.WebListener.FunctionalTests.xproj
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/Microsoft.AspNet.Server.WebListener.FunctionalTests.xproj
@@ -13,5 +13,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/OpaqueUpgradeTests.cs
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/OpaqueUpgradeTests.cs
@@ -71,6 +71,7 @@ namespace Microsoft.AspNet.Server.WebListener
             {
                 var httpContext = new DefaultHttpContext((IFeatureCollection)env);
                 await httpContext.Response.WriteAsync("Hello World");
+                await httpContext.Response.Body.FlushAsync();
                 try
                 {
                     var opaqueFeature = httpContext.GetFeature<IHttpUpgradeFeature>();
@@ -171,8 +172,8 @@ namespace Microsoft.AspNet.Server.WebListener
                 using (Stream stream = await SendOpaqueRequestAsync(method, address, extraHeader))
                 {
                     byte[] data = new byte[100];
-                    stream.WriteAsync(data, 0, 49).Wait();
-                    int read = stream.ReadAsync(data, 0, data.Length).Result;
+                    await stream.WriteAsync(data, 0, 49);
+                    int read = await stream.ReadAsync(data, 0, data.Length);
                     Assert.Equal(49, read);
                 }
             }

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/WebSocketTests.cs
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/WebSocketTests.cs
@@ -84,7 +84,6 @@ namespace Microsoft.AspNet.Server.WebListener
             {
                 HttpResponseMessage response = await SendRequestAsync(address);
                 Assert.Equal(200, (int)response.StatusCode);
-                Assert.True(response.Headers.TransferEncodingChunked.Value, "Chunked");
                 Assert.True(upgradeThrew.Value);
             }
         }

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/OpaqueUpgradeTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/OpaqueUpgradeTests.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Net.Http.Server
                 context.Dispose();
                 HttpResponseMessage response = await clientTask;
                 Assert.Equal(200, (int)response.StatusCode);
-                Assert.True(response.Headers.TransferEncodingChunked.Value, "Chunked");
                 Assert.Equal("Hello World", await response.Content.ReadAsStringAsync());
             }
         }

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/ResponseHeaderTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/ResponseHeaderTests.cs
@@ -349,13 +349,13 @@ namespace Microsoft.Net.Http.Server
                 responseHeaders.SetValues("Custom1", "value1a", "value1b");
                 responseHeaders.SetValues("Custom2", "value2a, value2b");
                 var body = context.Response.Body;
-                Assert.False(context.Response.HeadersSent);
+                Assert.False(context.Response.HasStarted);
                 body.Flush();
-                Assert.True(context.Response.HeadersSent);
+                Assert.True(context.Response.HasStarted);
                 var ex = Assert.Throws<InvalidOperationException>(() => context.Response.StatusCode = 404);
                 Assert.Equal("Headers already sent.", ex.Message);
                 ex = Assert.Throws<InvalidOperationException>(() => responseHeaders.Add("Custom3", new string[] { "value3a, value3b", "value3c" }));
-                Assert.Equal("The response headers cannot be modified because they have already been sent.", ex.Message);
+                Assert.Equal("The response headers cannot be modified because the response has already started.", ex.Message);
 
                 context.Dispose();
 
@@ -385,13 +385,13 @@ namespace Microsoft.Net.Http.Server
                 responseHeaders.SetValues("Custom1", "value1a", "value1b");
                 responseHeaders.SetValues("Custom2", "value2a, value2b");
                 var body = context.Response.Body;
-                Assert.False(context.Response.HeadersSent);
+                Assert.False(context.Response.HasStarted);
                 await body.FlushAsync();
-                Assert.True(context.Response.HeadersSent);
+                Assert.True(context.Response.HasStarted);
                 var ex = Assert.Throws<InvalidOperationException>(() => context.Response.StatusCode = 404);
                 Assert.Equal("Headers already sent.", ex.Message);
                 ex = Assert.Throws<InvalidOperationException>(() => responseHeaders.Add("Custom3", new string[] { "value3a, value3b", "value3c" }));
-                Assert.Equal("The response headers cannot be modified because they have already been sent.", ex.Message);
+                Assert.Equal("The response headers cannot be modified because the response has already started.", ex.Message);
 
                 context.Dispose();
 

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/WebSocketTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/WebSocketTests.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Net.Http.Server
                 context.Dispose();
                 HttpResponseMessage response = await clientTask;
                 Assert.Equal(200, (int)response.StatusCode);
-                Assert.True(response.Headers.TransferEncodingChunked.Value, "Chunked");
                 Assert.Equal("Hello World", await response.Content.ReadAsStringAsync());
             }
         }


### PR DESCRIPTION
#120

This implements a 4k write-behind response buffer similar to the one in Helios.  If the entire response is buffered then it will set the Content-Length for you.

I refactored the response stream to funnel all of the IO into Flush/Async to reduce duplication across Begin/Write/Async, Dispose, etc.. 

@anurse @muratg 
