### PR TITLE
Target net451 and use Marshal.SizeOf<T>.

### DIFF
--- a/src/Microsoft.Net.Http.Server/AuthenticationManager.cs
+++ b/src/Microsoft.Net.Http.Server/AuthenticationManager.cs
@@ -38,13 +38,8 @@ namespace Microsoft.Net.Http.Server
     /// </summary>
     public sealed class AuthenticationManager
     {
-#if DNXCORE50
         private static readonly int AuthInfoSize =
             Marshal.SizeOf<UnsafeNclNativeMethods.HttpApi.HTTP_SERVER_AUTHENTICATION_INFO>();
-#else
-        private static readonly int AuthInfoSize =
-            Marshal.SizeOf(typeof(UnsafeNclNativeMethods.HttpApi.HTTP_SERVER_AUTHENTICATION_INFO));
-#endif
 
         private WebListener _server;
         private AuthenticationSchemes _authSchemes;

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/Response.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/Response.cs
@@ -667,12 +667,7 @@ namespace Microsoft.Net.Http.Server
                             }
 
                             knownHeaderInfo[_nativeResponse.ResponseInfoCount].Type = HttpApi.HTTP_RESPONSE_INFO_TYPE.HttpResponseInfoTypeMultipleKnownHeaders;
-                            knownHeaderInfo[_nativeResponse.ResponseInfoCount].Length =
-#if DNXCORE50
-                                (uint)Marshal.SizeOf<HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS>();
-#else
-                                (uint)Marshal.SizeOf(typeof(HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS));
-#endif
+                            knownHeaderInfo[_nativeResponse.ResponseInfoCount].Length = (uint)Marshal.SizeOf<HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS>();
 
                             HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS header = new HttpApi.HTTP_MULTIPLE_KNOWN_HEADERS();
 

--- a/src/Microsoft.Net.Http.Server/TimeoutManager.cs
+++ b/src/Microsoft.Net.Http.Server/TimeoutManager.cs
@@ -35,13 +35,9 @@ namespace Microsoft.Net.Http.Server
     /// </summary>
     public sealed class TimeoutManager
     {
-#if DNXCORE50
         private static readonly int TimeoutLimitSize =
             Marshal.SizeOf<UnsafeNclNativeMethods.HttpApi.HTTP_TIMEOUT_LIMIT_INFO>();
-#else
-        private static readonly int TimeoutLimitSize =
-            Marshal.SizeOf(typeof(UnsafeNclNativeMethods.HttpApi.HTTP_TIMEOUT_LIMIT_INFO));
-#endif
+
         private WebListener _server;
         private int[] _timeouts;
         private uint _minSendBytesPerSecond;

--- a/src/Microsoft.Net.Http.Server/project.json
+++ b/src/Microsoft.Net.Http.Server/project.json
@@ -9,7 +9,7 @@
         "allowUnsafe": true
     },
     "frameworks": {
-        "net45": { },
+        "net451": { },
         "dnx451": { },
         "dnxcore50": {
             "dependencies": {

--- a/src/Microsoft.Net.WebSockets/WebSocketBuffer.cs
+++ b/src/Microsoft.Net.WebSockets/WebSocketBuffer.cs
@@ -50,13 +50,8 @@ namespace Microsoft.Net.WebSockets
         public const int MinSendBufferSize = 16;
         internal const int MinReceiveBufferSize = 256;
         internal const int MaxBufferSize = 64 * 1024;
-#if DNXCORE50
         private static readonly int SizeOfUInt = Marshal.SizeOf<uint>();
         private static readonly int SizeOfBool = Marshal.SizeOf<bool>();
-#else
-        private static readonly int SizeOfUInt = Marshal.SizeOf(typeof(uint));
-        private static readonly int SizeOfBool = Marshal.SizeOf(typeof(bool));
-#endif
         private static readonly int PropertyBufferSize = (2 * SizeOfUInt) + SizeOfBool + IntPtr.Size;
 
         private readonly int _ReceiveBufferSize;

--- a/src/Microsoft.Net.WebSockets/project.json
+++ b/src/Microsoft.Net.WebSockets/project.json
@@ -5,7 +5,8 @@
     },
     "compilationOptions": { "allowUnsafe": true },
     "frameworks": {
-        "net45": { },
+        "net451": { },
+        "dnx451": { },
         "dnxcore50": {
             "dependencies": {
                 "System.Collections": "4.0.10-beta-*",


### PR DESCRIPTION
#127

`Marshal.SizeOf(type)` is obsolete, use `Marshal.SizeOf<T>()` from 4.5.1.
@muratg @moozzyk 
