### PR TITLE
Add a Hosting dependency and Program.Main.

### DIFF
--- a/samples/HotAddSample/project.json
+++ b/samples/HotAddSample/project.json
@@ -1,12 +1,11 @@
 {
     "version": "1.0.0-*",
     "dependencies": {
-        "Microsoft.AspNet.Hosting": "1.0.0-*",
         "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
         "Microsoft.Framework.Logging.Console": "1.0.0-*"
     },
     "commands": {
-        "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:12345"
+        "web": "Microsoft.AspNet.Server.WebListener --server.urls http://localhost:12345"
     },
     "frameworks" : {
         "dnx451" : { },

--- a/samples/SelfHostServer/project.json
+++ b/samples/SelfHostServer/project.json
@@ -1,10 +1,9 @@
 {
     "dependencies": {
-        "Microsoft.AspNet.Hosting": "1.0.0-*",
         "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
         "Microsoft.Framework.Logging.Console": "1.0.0-*"
     },
-    "commands": { "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:8080" },
+    "commands": { "web": "Microsoft.AspNet.Server.WebListener --server.urls http://localhost:8080" },
     "frameworks": {
         "dnx451": { },
         "dnxcore50": { }

--- a/src/Microsoft.AspNet.Server.WebListener/Program.cs
+++ b/src/Microsoft.AspNet.Server.WebListener/Program.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+// WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF
+// TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR
+// NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing
+// permissions and limitations under the License.
+
+// -----------------------------------------------------------------------
+// <copyright file="AuthenticationManager.cs" company="Microsoft">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+
+namespace Microsoft.AspNet.Server.WebListener
+{
+    public class Program
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public Program(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public void Main(string[] args)
+        {
+            var program = new Hosting.Program(_serviceProvider);
+            var mergedArgs = new[] { "--server", "Microsoft.AspNet.Server.WebListener" }.Concat(args).ToArray();
+            program.Main(mergedArgs);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Server.WebListener/project.json
+++ b/src/Microsoft.AspNet.Server.WebListener/project.json
@@ -2,9 +2,7 @@
   "version": "1.0.0-*",
   "description": "ASP.NET 5 self-host web server.",
   "dependencies": {
-    "Microsoft.AspNet.Http.Features": "1.0.0-*",
-    "Microsoft.AspNet.Hosting.Server.Abstractions": "1.0.0-*",
-    "Microsoft.Framework.Logging.Abstractions": "1.0.0-*",
+    "Microsoft.AspNet.Hosting": "1.0.0-*",
     "Microsoft.Net.Http.Headers": "1.0.0-*",
     "Microsoft.Net.Http.Server": "1.0.0-*"
   },

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/project.json
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/project.json
@@ -3,7 +3,6 @@
         "test": "xunit.runner.aspnet"
     },
     "dependencies": {
-        "Microsoft.AspNet.Http": "1.0.0-*",
         "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
         "Microsoft.AspNet.Testing": "1.0.0-*",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"


### PR DESCRIPTION
#125

Hosting is required to run WebListener, but it didn't have a direct dependency, potentially causing issues in a project.

Also added a Program.Main so that commands can be simplified to:
`"web": "Microsoft.AspNet.Server.WebListener --server.urls http://localhost:12345"`

Question: Is `Microsoft.AspNet.Hosting.Server.Abstractions` still useful as an independent package or should it be merged back into Hosting?

@davidfowl @DamianEdwards @rynowak @muratg 
