### PR TITLE
Rearranging test port allocations to avoid test race conditions #152

### DIFF
--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/Utilities.cs
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/Utilities.cs
@@ -27,6 +27,9 @@ namespace Microsoft.AspNet.Server.WebListener
 {
     internal static class Utilities
     {
+        // When tests projects are run in parallel, overlapping port ranges can cause a race condition when looking for free 
+        // ports during dynamic port allocation. To avoid this, make sure the port range here is different from the range in 
+        // Microsoft.Net.Http.Server.
         private const int BasePort = 5001;
         private const int MaxPort = 8000;
         private static int NextPort = BasePort;

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/Utilities.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/Utilities.cs
@@ -6,8 +6,11 @@ namespace Microsoft.Net.Http.Server
 {
     internal static class Utilities
     {
-        private const int BasePort = 5001;
-        private const int MaxPort = 8000;
+        // When tests projects are run in parallel, overlapping port ranges can cause a race condition when looking for free 
+        // ports during dynamic port allocation. To avoid this, make sure the port range here is different from the range in 
+        // Microsoft.AspNet.Server.WebListener.
+        private const int BasePort = 8001;
+        private const int MaxPort = 11000;
         private static int NextPort = BasePort;
         private static object PortLock = new object();
 


### PR DESCRIPTION
#152 @Tratcher
