### PR TITLE
Do not unescape forward slashes in the request path (#146).

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,3 +1,3 @@
 {
-    "projects": ["src"]
+    "projects": ["src", "test"]
 }

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/Request.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/Request.cs
@@ -109,21 +109,21 @@ namespace Microsoft.Net.Http.Server
             }
 
             UrlPrefix prefix = httpContext.Server.UrlPrefixes.GetPrefix((int)_contextId);
-            string orriginalPath = RequestPath;
+            string originalPath = RequestPath;
 
             // These paths are both unescaped already.
-            if (orriginalPath.Length == prefix.Path.Length - 1)
+            if (originalPath.Length == prefix.Path.Length - 1)
             {
                 // They matched exactly except for the trailing slash.
-                _pathBase = orriginalPath;
+                _pathBase = originalPath;
                 _path = string.Empty;
             }
             else
             {
                 // url: /base/path, prefix: /base/, base: /base, path: /path
                 // url: /, prefix: /, base: , path: /
-                _pathBase = orriginalPath.Substring(0, prefix.Path.Length - 1);
-                _path = orriginalPath.Substring(prefix.Path.Length - 1);
+                _pathBase = originalPath.Substring(0, prefix.Path.Length - 1);
+                _path = originalPath.Substring(prefix.Path.Length - 1);
             }
 
             int major = memoryBlob.RequestBlob->Version.MajorVersion;
@@ -386,21 +386,7 @@ namespace Microsoft.Net.Http.Server
         {
             get { return IsSecureConnection ? Constants.HttpsScheme : Constants.HttpScheme; }
         }
-        /*
-        internal Uri RequestUri
-        {
-            get
-            {
-                if (_requestUri == null)
-                {
-                    _requestUri = RequestUriBuilder.GetRequestUri(
-                        _rawUrl, RequestScheme, _cookedUrlHost, _cookedUrlPath, _cookedUrlQuery);
-                }
 
-                return _requestUri;
-            }
-        }
-        */
         internal string RequestPath
         {
             get


### PR DESCRIPTION
- Set `RequestUriBuilder.UseCookedRequestUrl` to `false` to trigger raw parsing.
- The parsing behavior seemed wrong. It was decoding the path and re-encoding it right after. I changed this to that `_requestUriString` builds a decoded string. `%2F` is skipped in the decoding process.
- The handling of `%uXXXX` doesn't seem to work. I tried adding a test for that case and http.sys hangs on it. The [Wikipedia entry for percent encoding](https://en.wikipedia.org/wiki/Percent-encoding) contains this note:
  
  There exists a non-standard encoding for Unicode characters: %uxxxx, where xxxx is a UTF-16 code unit represented as four hexadecimal digits. This behavior is not specified by any RFC and has been rejected by the W3C.
#146

cc @Tratcher @troydai @davidfowl 
