### PR TITLE
Enable tests on CoreCLR (#143)

### DIFF
--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/AuthenticationTests.cs
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/AuthenticationTests.cs
@@ -21,6 +21,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http.Features.Authentication;
+using Microsoft.AspNet.Testing.xunit;
 using Xunit;
 using AuthenticationSchemes = Microsoft.Net.Http.Server.AuthenticationSchemes;
 
@@ -52,11 +53,12 @@ namespace Microsoft.AspNet.Server.WebListener
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(AuthenticationSchemes.Negotiate)]
         [InlineData(AuthenticationSchemes.NTLM)]
         // [InlineData(AuthenticationSchemes.Digest)] // TODO: Not implemented
         [InlineData(AuthenticationSchemes.Basic)]
+        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "HttpClientHandler issue (https://github.com/dotnet/corefx/issues/5045).")]
         public async Task AuthType_RequireAuth_ChallengesAdded(AuthenticationSchemes authType)
         {
             string address;
@@ -71,11 +73,12 @@ namespace Microsoft.AspNet.Server.WebListener
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(AuthenticationSchemes.Negotiate)]
         [InlineData(AuthenticationSchemes.NTLM)]
         // [InlineData(AuthenticationSchemes.Digest)] // TODO: Not implemented
         [InlineData(AuthenticationSchemes.Basic)]
+        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "HttpClientHandler issue (https://github.com/dotnet/corefx/issues/5045).")]
         public async Task AuthType_AllowAnonymousButSpecify401_ChallengesAdded(AuthenticationSchemes authType)
         {
             string address;
@@ -94,7 +97,8 @@ namespace Microsoft.AspNet.Server.WebListener
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "HttpClientHandler issue (https://github.com/dotnet/corefx/issues/5045).")]
         public async Task MultipleAuthTypes_AllowAnonymousButSpecify401_ChallengesAdded()
         {
             string address;
@@ -293,12 +297,13 @@ namespace Microsoft.AspNet.Server.WebListener
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(AuthenticationSchemes.Negotiate)]
         [InlineData(AuthenticationSchemes.NTLM)]
         // [InlineData(AuthenticationSchemes.Digest)]
         [InlineData(AuthenticationSchemes.Basic)]
         [InlineData(AuthenticationSchemes.Negotiate | AuthenticationSchemes.NTLM | /*AuthenticationSchemes.Digest |*/ AuthenticationSchemes.Basic)]
+        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "HttpClientHandler issue (https://github.com/dotnet/corefx/issues/5045).")]
         public async Task AuthTypes_ChallengeWithoutAuthTypes_AllChallengesSent(AuthenticationSchemes authType)
         {
             string address;
@@ -317,12 +322,13 @@ namespace Microsoft.AspNet.Server.WebListener
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(AuthenticationSchemes.Negotiate)]
         [InlineData(AuthenticationSchemes.NTLM)]
         // [InlineData(AuthenticationSchemes.Digest)]
         [InlineData(AuthenticationSchemes.Basic)]
         [InlineData(AuthenticationSchemes.Negotiate | AuthenticationSchemes.NTLM | /*AuthenticationSchemes.Digest |*/ AuthenticationSchemes.Basic)]
+        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "HttpClientHandler issue (https://github.com/dotnet/corefx/issues/5045).")]
         public async Task AuthTypes_ChallengeWithAllAuthTypes_AllChallengesSent(AuthenticationSchemes authType)
         {
             string address;
@@ -344,11 +350,12 @@ namespace Microsoft.AspNet.Server.WebListener
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(AuthenticationSchemes.Negotiate)]
         [InlineData(AuthenticationSchemes.NTLM)]
         // [InlineData(AuthenticationSchemes.Digest)]
         [InlineData(AuthenticationSchemes.Basic)]
+        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "HttpClientHandler issue (https://github.com/dotnet/corefx/issues/5045).")]
         public async Task AuthTypes_ChallengeOneAuthType_OneChallengeSent(AuthenticationSchemes authType)
         {
             string address;

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/HttpsTests.cs
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/HttpsTests.cs
@@ -115,7 +115,11 @@ namespace Microsoft.AspNet.Server.WebListener
         private async Task<string> SendRequestAsync(string uri, 
             X509Certificate cert = null)
         {
-            WebRequestHandler handler = new WebRequestHandler();
+#if DNX451
+            var handler = new WebRequestHandler();
+#else
+            var handler = new WinHttpHandler();
+#endif
             handler.ServerCertificateValidationCallback = (a, b, c, d) => true;
             if (cert != null)
             {
@@ -129,7 +133,11 @@ namespace Microsoft.AspNet.Server.WebListener
 
         private async Task<string> SendRequestAsync(string uri, string upload)
         {
-            WebRequestHandler handler = new WebRequestHandler();
+#if DNX451
+            var handler = new WebRequestHandler();
+#else
+            var handler = new WinHttpHandler();
+#endif
             handler.ServerCertificateValidationCallback = (a, b, c, d) => true;
             using (HttpClient client = new HttpClient(handler))
             {

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/OpaqueUpgradeTests.cs
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/OpaqueUpgradeTests.cs
@@ -24,7 +24,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Features;
-using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Testing.xunit;
 using Xunit;
 
@@ -218,6 +217,7 @@ namespace Microsoft.AspNet.Server.WebListener
             // Connect with a socket
             Uri uri = new Uri(address);
             TcpClient client = new TcpClient();
+
             try
             {
                 await client.ConnectAsync(uri.Host, uri.Port);
@@ -235,7 +235,7 @@ namespace Microsoft.AspNet.Server.WebListener
             }
             catch (Exception)
             {
-                client.Close();
+                ((IDisposable)client).Dispose();
                 throw;
             }
         }

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/RequestBodyTests.cs
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/RequestBodyTests.cs
@@ -191,6 +191,7 @@ namespace Microsoft.AspNet.Server.WebListener
             // Connect with a socket
             Uri uri = new Uri(address);
             TcpClient client = new TcpClient();
+
             try
             {
                 await client.ConnectAsync(uri.Host, uri.Port);
@@ -204,7 +205,7 @@ namespace Microsoft.AspNet.Server.WebListener
             }
             catch (Exception)
             {
-                client.Close();
+                ((IDisposable)client).Dispose();
                 throw;
             }
         }

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/RequestHeaderTests.cs
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/RequestHeaderTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNet.Server.WebListener
 
             byte[] response = new byte[1024 * 5];
             await Task.Run(() => socket.Receive(response));
-            socket.Close();
+            socket.Dispose();
         }
     }
 }

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/ResponseHeaderTests.cs
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/ResponseHeaderTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNet.Server.WebListener
                 Assert.Equal(0, response.ContentLength);
                 Assert.NotNull(response.Headers["Date"]);
                 Assert.Equal("Microsoft-HTTPAPI/2.0", response.Headers["Server"]);
-                Assert.Equal(new string[] { "custom1" }, response.Headers.GetValues("WWW-Authenticate"));
+                Assert.Equal("custom1", response.Headers["WWW-Authenticate"]);
             }
         }
 
@@ -94,7 +94,11 @@ namespace Microsoft.AspNet.Server.WebListener
                 Assert.Equal(0, response.ContentLength);
                 Assert.NotNull(response.Headers["Date"]);
                 Assert.Equal("Microsoft-HTTPAPI/2.0", response.Headers["Server"]);
+#if DNXCORE50 // WebHeaderCollection.GetValues() not available in CoreCLR.
+                Assert.Equal("custom1, and custom2, custom3", response.Headers["WWW-Authenticate"]);
+#else
                 Assert.Equal(new string[] { "custom1, and custom2", "custom3" }, response.Headers.GetValues("WWW-Authenticate"));
+#endif
             }
         }
 
@@ -118,7 +122,11 @@ namespace Microsoft.AspNet.Server.WebListener
                 Assert.Equal(0, response.ContentLength);
                 Assert.NotNull(response.Headers["Date"]);
                 Assert.Equal("Microsoft-HTTPAPI/2.0", response.Headers["Server"]);
+#if DNXCORE50 // WebHeaderCollection.GetValues() not available in CoreCLR.
+                Assert.Equal("custom1, and custom2, custom3", response.Headers["Custom-Header1"]);
+#else
                 Assert.Equal(new string[] { "custom1, and custom2", "custom3" }, response.Headers.GetValues("Custom-Header1"));
+#endif
             }
         }
 

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/ResponseSendFileTests.cs
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/ResponseSendFileTests.cs
@@ -25,7 +25,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http.Features;
-using Microsoft.AspNet.Http.Internal;
 using Xunit;
 
 namespace Microsoft.AspNet.Server.WebListener
@@ -38,7 +37,7 @@ namespace Microsoft.AspNet.Server.WebListener
 
         public ResponseSendFileTests()
         {
-            AbsoluteFilePath = Directory.GetFiles(Environment.CurrentDirectory).First();
+            AbsoluteFilePath = Directory.GetFiles(Directory.GetCurrentDirectory()).First();
             RelativeFilePath = Path.GetFileName(AbsoluteFilePath);
             FileLength = new FileInfo(AbsoluteFilePath).Length;
         }

--- a/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/project.json
+++ b/test/Microsoft.AspNet.Server.WebListener.FunctionalTests/project.json
@@ -13,6 +13,13 @@
                 "System.Net.Http": "",
                 "System.Net.Http.WebRequest": ""
             }
+        },
+        "dnxcore50": {
+            "dependencies": {
+                "System.Net.Http.WinHttpHandler": "4.0.0-*",
+                "System.Net.Requests": "4.0.11-*",
+                "System.Net.WebHeaderCollection": "4.0.1-*"
+            }
         }
     }
 }

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/AuthenticationTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/AuthenticationTests.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Net.Http.Server
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(AuthenticationSchemes.Negotiate)]
         [InlineData(AuthenticationSchemes.NTLM)]
         // [InlineData(AuthenticationType.Digest)] // TODO: Not implemented
         [InlineData(AuthenticationSchemes.Basic)]
+        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "HttpClientHandler issue (https://github.com/dotnet/corefx/issues/5045).")]
         public async Task AuthType_RequireAuth_ChallengesAdded(AuthenticationSchemes authType)
         {
             string address;
@@ -57,18 +58,18 @@ namespace Microsoft.Net.Http.Server
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
                 var contextTask = server.GetContextAsync(); // Fails when the server shuts down, the challenge happens internally.
-
                 var response = await responseTask;
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
                 Assert.Equal(authType.ToString(), response.Headers.WwwAuthenticate.ToString(), StringComparer.OrdinalIgnoreCase);
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(AuthenticationSchemes.Negotiate)]
         [InlineData(AuthenticationSchemes.NTLM)]
         // [InlineData(AuthenticationSchemes.Digest)] // TODO: Not implemented
         [InlineData(AuthenticationSchemes.Basic)]
+        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "HttpClientHandler issue (https://github.com/dotnet/corefx/issues/5045).")]
         public async Task AuthType_AllowAnonymousButSpecify401_ChallengesAdded(AuthenticationSchemes authType)
         {
             string address;
@@ -89,7 +90,8 @@ namespace Microsoft.Net.Http.Server
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "HttpClientHandler issue (https://github.com/dotnet/corefx/issues/5045).")]
         public async Task MultipleAuthTypes_AllowAnonymousButSpecify401_ChallengesAdded()
         {
             string address;
@@ -216,7 +218,7 @@ namespace Microsoft.Net.Http.Server
         {
             HttpClientHandler handler = new HttpClientHandler();
             handler.UseDefaultCredentials = useDefaultCredentials;
-            using (HttpClient client = new HttpClient(handler))
+            using (HttpClient client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) })
             {
                 return await client.GetAsync(uri);
             }

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/HttpsTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/HttpsTests.cs
@@ -107,7 +107,11 @@ namespace Microsoft.Net.Http.Server
         private async Task<string> SendRequestAsync(string uri, 
             X509Certificate cert = null)
         {
+#if DNX451
             WebRequestHandler handler = new WebRequestHandler();
+#else
+            WinHttpHandler handler = new WinHttpHandler();
+#endif
             handler.ServerCertificateValidationCallback = (a, b, c, d) => true;
             if (cert != null)
             {
@@ -121,7 +125,11 @@ namespace Microsoft.Net.Http.Server
 
         private async Task<string> SendRequestAsync(string uri, string upload)
         {
+#if DNX451
             WebRequestHandler handler = new WebRequestHandler();
+#else
+            WinHttpHandler handler = new WinHttpHandler();
+#endif
             handler.ServerCertificateValidationCallback = (a, b, c, d) => true;
             using (HttpClient client = new HttpClient(handler))
             {

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/OpaqueUpgradeTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/OpaqueUpgradeTests.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Net.Http.Server
             }
             catch (Exception)
             {
-                client.Close();
+                ((IDisposable)client).Dispose();
                 throw;
             }
         }

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/RequestBodyTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/RequestBodyTests.cs
@@ -352,7 +352,7 @@ namespace Microsoft.Net.Http.Server
             }
             catch (Exception)
             {
-                client.Close();
+                ((IDisposable)client).Dispose();
                 throw;
             }
         }

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/RequestHeaderTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/RequestHeaderTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Net.Http.Server
 
             byte[] response = new byte[1024 * 5];
             await Task.Run(() => socket.Receive(response));
-            socket.Close();
+            socket.Dispose();
         }
     }
 }

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/ResponseHeaderTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/ResponseHeaderTests.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Net.Http.Server
                 Assert.Equal(0, response.ContentLength);
                 Assert.NotNull(response.Headers["Date"]);
                 Assert.Equal("Microsoft-HTTPAPI/2.0", response.Headers["Server"]);
-                Assert.Equal(new string[] { "custom1" }, response.Headers.GetValues("WWW-Authenticate"));
+                Assert.Equal("custom1", response.Headers["WWW-Authenticate"]);
             }
         }
 
@@ -217,7 +217,11 @@ namespace Microsoft.Net.Http.Server
                 Assert.Equal(0, response.ContentLength);
                 Assert.NotNull(response.Headers["Date"]);
                 Assert.Equal("Microsoft-HTTPAPI/2.0", response.Headers["Server"]);
+#if DNXCORE50 // WebHeaderCollection.GetValues() not available in CoreCLR.
+                Assert.Equal("custom1, and custom2, custom3", response.Headers["WWW-Authenticate"]);
+#else
                 Assert.Equal(new string[] { "custom1, and custom2", "custom3" }, response.Headers.GetValues("WWW-Authenticate"));
+#endif
             }
         }
 
@@ -242,7 +246,11 @@ namespace Microsoft.Net.Http.Server
                 Assert.Equal(0, response.ContentLength);
                 Assert.NotNull(response.Headers["Date"]);
                 Assert.Equal("Microsoft-HTTPAPI/2.0", response.Headers["Server"]);
+#if DNXCORE50 // WebHeaderCollection.GetValues() not available in CoreCLR.
+                Assert.Equal("custom1, and custom2, custom3", response.Headers["Custom-Header1"]);
+#else
                 Assert.Equal(new string[] { "custom1, and custom2", "custom3" }, response.Headers.GetValues("Custom-Header1"));
+#endif
             }
         }
 

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/ResponseSendFileTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/ResponseSendFileTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Net.Http.Server
         
         public ResponseSendFileTests()
         {
-            AbsoluteFilePath = Directory.GetFiles(Environment.CurrentDirectory).First();
+            AbsoluteFilePath = Directory.GetFiles(Directory.GetCurrentDirectory()).First();
             RelativeFilePath = Path.GetFileName(AbsoluteFilePath);
             FileLength = new FileInfo(AbsoluteFilePath).Length;
         }
@@ -205,9 +205,9 @@ namespace Microsoft.Net.Http.Server
         [Fact]
         public async Task ResponseSendFile_EmptyFileCountUnspecified_SetsChunkedAndFlushesHeaders()
         {
-            var emptyFilePath = Path.Combine(Environment.CurrentDirectory, "zz_" + Guid.NewGuid().ToString() + "EmptyTestFile.txt");
+            var emptyFilePath = Path.Combine(Directory.GetCurrentDirectory(), "zz_" + Guid.NewGuid().ToString() + "EmptyTestFile.txt");
             var emptyFile = File.Create(emptyFilePath, 1024);
-            emptyFile.Close();
+            emptyFile.Dispose();
 
             string address;
             using (var server = Utilities.CreateHttpServer(out address))

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/ServerTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/ServerTests.cs
@@ -8,6 +8,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.Net.Http.Server
@@ -122,11 +123,11 @@ namespace Microsoft.Net.Http.Server
                 context.Abort();
                 Assert.True(canceled.WaitOne(interval), "Aborted");
                 Assert.True(ct.IsCancellationRequested, "IsCancellationRequested");
-
+#if !DNXCORE50
                 // HttpClient re-tries the request because it doesn't know if the request was received.
                 context = await server.GetContextAsync();
                 context.Abort();
-
+#endif
                 await Assert.ThrowsAsync<HttpRequestException>(() => responseTask);
             }
         }
@@ -246,7 +247,6 @@ namespace Microsoft.Net.Http.Server
 
         private async Task<string> SendRequestAsync(string uri)
         {
-            ServicePointManager.DefaultConnectionLimit = 100;
             using (HttpClient client = new HttpClient())
             {
                 return await client.GetStringAsync(uri);

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/SkipOffDomainAttribute.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/SkipOffDomainAttribute.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.DirectoryServices.ActiveDirectory;
 using Microsoft.AspNet.Testing.xunit;
 
 namespace Microsoft.Net.Http.Server
@@ -19,7 +18,9 @@ namespace Microsoft.Net.Http.Server
             {
                 try
                 {
-                    return !string.IsNullOrEmpty(Domain.GetComputerDomain().Name);
+#if DNX451
+                    return !string.IsNullOrEmpty(System.DirectoryServices.ActiveDirectory.Domain.GetComputerDomain().Name);
+#endif
                 }
                 catch
                 {

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/project.json
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/project.json
@@ -15,6 +15,14 @@
         "System.Net.Http": "",
         "System.Net.Http.WebRequest": ""
       }
+    },
+    "dnxcore50": {
+      "dependencies": {
+        "System.Net.Http": "4.0.1-*",
+        "System.Net.Http.WinHttpHandler": "4.0.0-*",
+        "System.Net.Requests": "4.0.11-*",
+        "System.Net.WebSockets.Client": "4.0.0-*"
+      }
     }
   }
 }


### PR DESCRIPTION
- This required a few changes here and there (e.g. calling `Dispose()` instead of `Close()` on some types).
- Some tests hang (https://github.com/aspnet/WebListener/issues/164), so they had to be disabled.
- Other tests had to be changed or had portions of them disabled on CoreCLR to accommodate for differences in the implementation of `HttpClient`. Some authentication tests are disabled because of a bug in `HttpClientHandler` (https://github.com/dotnet/corefx/issues/5045)
#143

cc @Tratcher @JunTaoLuo 
