### PR TITLE
React to HttpAbstractions namespace changes

### DIFF
--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/DummyApplication.cs
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/DummyApplication.cs
@@ -20,7 +20,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Http.Internal;
 
 namespace Microsoft.AspNetCore.Server.WebListener
 {

--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/RequestBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/RequestBodyTests.cs
@@ -23,8 +23,6 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Http.Internal;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.WebListener

--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/RequestHeaderTests.cs
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/RequestHeaderTests.cs
@@ -20,8 +20,6 @@ using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.Extensions.Primitives;
 using Xunit;
 

--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ResponseBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ResponseBodyTests.cs
@@ -23,9 +23,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Http.Internal;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.WebListener

--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ResponseCachingTests.cs
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ResponseCachingTests.cs
@@ -4,8 +4,6 @@ using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Http.Internal;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.WebListener.FunctionalTests

--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ResponseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ResponseTests.cs
@@ -20,7 +20,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Http.Internal;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.WebListener


### PR DESCRIPTION
- aspnet/HttpAbstractions#549 and aspnet/HttpAbstractions#592
- clean up `using`s
