### PR TITLE
Log stack trace when logging exceptions #198

### DIFF
--- a/src/Microsoft.AspNetCore.Server.WebListener/LogHelper.cs
+++ b/src/Microsoft.AspNetCore.Server.WebListener/LogHelper.cs
@@ -51,32 +51,27 @@ namespace Microsoft.AspNetCore.Server.WebListener
             }
         }
 
-        internal static void LogDebug(ILogger logger, string data)
+        internal static void LogDebug(ILogger logger, string location, Exception exception)
         {
             if (logger == null)
             {
-                Debug.WriteLine(data);
+                Console.WriteLine(location + Environment.NewLine + exception.ToString());
             }
             else
             {
-                logger.LogDebug(data);
+                logger.LogDebug(0, exception, location);
             }
-        }
-
-        internal static void LogDebug(ILogger logger, string location, Exception exception)
-        {
-            LogDebug(logger, location + "; " + exception.ToString());
         }
 
         internal static void LogException(ILogger logger, string location, Exception exception)
         {
             if (logger == null)
             {
-                Debug.WriteLine(exception);
+                Debug.WriteLine(location + Environment.NewLine + exception.ToString());
             }
             else
             {
-                logger.LogError(location, exception);
+                logger.LogError(0, exception, location);
             }
         }
 


### PR DESCRIPTION
fixes #198 

Previously:

```
fail: Microsoft.AspNetCore.Server.WebListener.MessagePump[0]
      ProcessRequestAsync
```

With this change:

```
fail: Microsoft.AspNetCore.Server.WebListener.MessagePump[0]
      ProcessRequestAsync
System.Exception: User exception
         at SelfHostServer.Startup.<>c.<<Configure>b__1_0>d.MoveNext() in C:\gh\
WebListener\samples\SelfHostServer\Startup.cs:line 33
      --- End of stack trace from previous location where exception was thrown -
--
         at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task
task)
         at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebug
gerNotification(Task task)
         at Microsoft.AspNetCore.Hosting.Internal.RequestServicesContainerMiddle
ware.<Invoke>d__3.MoveNext()
      --- End of stack trace from previous location where exception was thrown -
--
         at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task
task)
         at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebug
gerNotification(Task task)
         at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTa
skAwaiter.GetResult()
         at Microsoft.AspNetCore.Server.WebListener.MessagePump.<ProcessRequestA
sync>d__27.MoveNext() in C:\gh\WebListener\src\Microsoft.AspNetCore.Server.WebLi
stener\MessagePump.cs:line 191
```
