### PR TITLE
Rename UrlPrefix.Whole to FullPrefix. Make IsHeadMethod internal

### DIFF
--- a/src/Microsoft.Net.Http.Server/RequestProcessing/Request.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/Request.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Net.Http.Server
 
         internal HttpApi.HTTP_VERB KnownMethod { get; }
 
-        public bool IsHeadMethod => KnownMethod == HttpApi.HTTP_VERB.HttpVerbHEAD;
+        internal bool IsHeadMethod => KnownMethod == HttpApi.HTTP_VERB.HttpVerbHEAD;
 
         public string Method { get; }
 

--- a/src/Microsoft.Net.Http.Server/UrlPrefix.cs
+++ b/src/Microsoft.Net.Http.Server/UrlPrefix.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Net.Http.Server
             Port = port;
             PortValue = portValue;
             Path = path;
-            Whole = string.Format(CultureInfo.InvariantCulture, "{0}://{1}:{2}{3}", Scheme, Host, Port, Path);
+            FullPrefix = string.Format(CultureInfo.InvariantCulture, "{0}://{1}:{2}{3}", Scheme, Host, Port, Path);
         }
 
         /// <summary>
@@ -169,21 +169,21 @@ namespace Microsoft.Net.Http.Server
         public string Port { get; private set; }
         public int PortValue { get; private set; }
         public string Path { get; private set; }
-        public string Whole { get; private set; }
+        public string FullPrefix { get; private set; }
 
         public override bool Equals(object obj)
         {
-            return string.Equals(Whole, Convert.ToString(obj), StringComparison.OrdinalIgnoreCase);
+            return string.Equals(FullPrefix, Convert.ToString(obj), StringComparison.OrdinalIgnoreCase);
         }
 
         public override int GetHashCode()
         {
-            return StringComparer.OrdinalIgnoreCase.GetHashCode(Whole);
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(FullPrefix);
         }
 
         public override string ToString()
         {
-            return Whole;
+            return FullPrefix;
         }
     }
 }

--- a/src/Microsoft.Net.Http.Server/UrlPrefixCollection.cs
+++ b/src/Microsoft.Net.Http.Server/UrlPrefixCollection.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Net.Http.Server
                 var id = _nextId++;
                 if (_webListener.IsListening)
                 {
-                    _webListener.UrlGroup.RegisterPrefix(item.Whole, id);
+                    _webListener.UrlGroup.RegisterPrefix(item.FullPrefix, id);
                 }
                 _prefixes.Add(id, item);
             }
@@ -108,7 +108,7 @@ namespace Microsoft.Net.Http.Server
                         id = pair.Key;
                         if (_webListener.IsListening)
                         {
-                            _webListener.UrlGroup.UnregisterPrefix(pair.Value.Whole);
+                            _webListener.UrlGroup.UnregisterPrefix(pair.Value.FullPrefix);
                         }
                     }
                 }
@@ -142,7 +142,7 @@ namespace Microsoft.Net.Http.Server
                 foreach (var pair in _prefixes)
                 {
                     // We'll get this index back on each request and use it to look up the prefix to calculate PathBase.
-                    _webListener.UrlGroup.RegisterPrefix(pair.Value.Whole, pair.Key);
+                    _webListener.UrlGroup.RegisterPrefix(pair.Value.FullPrefix, pair.Key);
                 }
             }
         }
@@ -155,7 +155,7 @@ namespace Microsoft.Net.Http.Server
                 foreach (var prefix in _prefixes.Values)
                 {
                     // ignore possible failures
-                    _webListener.UrlGroup.UnregisterPrefix(prefix.Whole);
+                    _webListener.UrlGroup.UnregisterPrefix(prefix.FullPrefix);
                 }
             }
         }

--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ResponseCachingTests.cs
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ResponseCachingTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Server.WebListener.FunctionalTests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/aspnet/WebListener/issues/210")]
         public async Task Caching_JustPublic_NotCached()
         {
             var requestCount = 1;


### PR DESCRIPTION
#160 Smaller API feedback items

Also disabling another flaky caching test.
