### PR TITLE
Move settings from WebListener to their own object

### DIFF
--- a/samples/HelloWorld/Program.cs
+++ b/samples/HelloWorld/Program.cs
@@ -16,9 +16,11 @@ namespace HelloWorld
         
         public static async Task Run(string[] args)
         {
-            using (WebListener listener = new WebListener())
+            var settings = new WebListenerSettings();
+            settings.UrlPrefixes.Add("http://localhost:8080");
+
+            using (WebListener listener = new WebListener(settings))
             {
-                listener.UrlPrefixes.Add("http://localhost:8080");
                 listener.Start();
 
                 Console.WriteLine("Running...");

--- a/samples/HotAddSample/Startup.cs
+++ b/samples/HotAddSample/Startup.cs
@@ -16,7 +16,7 @@ namespace HotAddSample
         {
             loggerfactory.AddConsole(LogLevel.Information);
 
-            var addresses = app.ServerFeatures.Get<WebListener>().UrlPrefixes;
+            var addresses = app.ServerFeatures.Get<WebListener>().Settings.UrlPrefixes;
             addresses.Add("http://localhost:12346/pathBase/");
 
             app.Use(async (context, next) =>

--- a/samples/SelfHostServer/Startup.cs
+++ b/samples/SelfHostServer/Startup.cs
@@ -19,8 +19,8 @@ namespace SelfHostServer
             // Server options can be configured here instead of in Main.
             services.Configure<WebListenerOptions>(options =>
             {
-                options.Listener.AuthenticationManager.AuthenticationSchemes = AuthenticationSchemes.None;
-                options.Listener.AuthenticationManager.AllowAnonymous = true;
+                options.ListenerSettings.Authentication.Schemes = AuthenticationSchemes.None;
+                options.ListenerSettings.Authentication.AllowAnonymous = true;
             });
         }
 
@@ -52,8 +52,8 @@ namespace SelfHostServer
                 .UseStartup<Startup>()
                 .UseWebListener(options =>
                 {
-                    options.Listener.AuthenticationManager.AuthenticationSchemes = AuthenticationSchemes.None;
-                    options.Listener.AuthenticationManager.AllowAnonymous = true;
+                    options.ListenerSettings.Authentication.Schemes = AuthenticationSchemes.None;
+                    options.ListenerSettings.Authentication.AllowAnonymous = true;
                 })
                 .Build();
 

--- a/src/Microsoft.AspNetCore.Server.WebListener/Internal/WebListenerOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Server.WebListener/Internal/WebListenerOptionsSetup.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Open Technologies, Inc.
+﻿// Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.WebListener.Internal
 
         public void Configure(WebListenerOptions options)
         {
-            options.Listener = new Microsoft.Net.Http.Server.WebListener(_loggerFactory);
+            options.ListenerSettings.Logger = _loggerFactory.CreateLogger<Microsoft.Net.Http.Server.WebListener>();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.WebListener/MessagePump.cs
+++ b/src/Microsoft.AspNetCore.Server.WebListener/MessagePump.cs
@@ -57,15 +57,16 @@ namespace Microsoft.AspNetCore.Server.WebListener
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
 
-            _listener = options.Value?.Listener ?? new Microsoft.Net.Http.Server.WebListener(loggerFactory);
+            var optionsInstance = options.Value;
+            _listener = new Microsoft.Net.Http.Server.WebListener(optionsInstance.ListenerSettings);
             _logger = LogHelper.CreateLogger(loggerFactory, typeof(MessagePump));
             Features = new FeatureCollection();
             _serverAddresses = new ServerAddressesFeature();
             Features.Set<IServerAddressesFeature>(_serverAddresses);
 
             _processRequest = new Action<object>(ProcessRequestAsync);
-            _maxAccepts = options.Value?.MaxAccepts ?? WebListenerOptions.DefaultMaxAccepts;
-            EnableResponseCaching = options.Value?.EnableResponseCaching ?? true;
+            _maxAccepts = optionsInstance.MaxAccepts;
+            EnableResponseCaching = optionsInstance.EnableResponseCaching;
             _shutdownSignal = new ManualResetEvent(false);
         }
 
@@ -94,7 +95,7 @@ namespace Microsoft.AspNetCore.Server.WebListener
 
             _application = new ApplicationWrapper<TContext>(application);
 
-            if (_listener.UrlPrefixes.Count == 0)
+            if (_listener.Settings.UrlPrefixes.Count == 0)
             {
                 throw new InvalidOperationException("No address prefixes were defined.");
             }
@@ -224,7 +225,7 @@ namespace Microsoft.AspNetCore.Server.WebListener
         {
             foreach (var value in addresses)
             {
-                listener.UrlPrefixes.Add(UrlPrefix.Create(value));
+                listener.Settings.UrlPrefixes.Add(UrlPrefix.Create(value));
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.WebListener/WebListenerOptions.cs
+++ b/src/Microsoft.AspNetCore.Server.WebListener/WebListenerOptions.cs
@@ -16,6 +16,7 @@
 // permissions and limitations under the License.
 
 using System;
+using Microsoft.Net.Http.Server;
 
 namespace Microsoft.AspNetCore.Server.WebListener
 {
@@ -23,10 +24,21 @@ namespace Microsoft.AspNetCore.Server.WebListener
     {
         internal static readonly int DefaultMaxAccepts = 5 * Environment.ProcessorCount;
 
-        public Microsoft.Net.Http.Server.WebListener Listener { get; set; } = new Microsoft.Net.Http.Server.WebListener();
+        /// <summary>
+        /// Settings for the underlying WebListener instance.
+        /// </summary>
+        public WebListenerSettings ListenerSettings { get; } = new WebListenerSettings();
 
+        /// <summary>
+        /// The maximum number of concurrent calls to WebListener.AcceptAsync().
+        /// </summary>
         public int MaxAccepts { get; set; } = DefaultMaxAccepts;
 
+        /// <summary>
+        /// Attempts kernel mode caching for responses with eligible headers. The response may not include
+        /// Set-Cookie, Vary, or Pragma headers. It must include a Cache-Control header with Public and
+        /// either a Shared-Max-Age or Max-Age value, or an Expires header.
+        /// </summary>
         public bool EnableResponseCaching { get; set; } = true;
     }
 }

--- a/src/Microsoft.Net.Http.Server/LogHelper.cs
+++ b/src/Microsoft.Net.Http.Server/LogHelper.cs
@@ -29,16 +29,6 @@ namespace Microsoft.Net.Http.Server
 {
     internal static class LogHelper
     {
-        internal static ILogger CreateLogger(ILoggerFactory factory, Type type)
-        {
-            if (factory == null)
-            {
-                return new NullLogger();
-            }
-
-            return factory.CreateLogger(type.FullName);
-        }
-
         internal static void LogInfo(ILogger logger, string data)
         {
             if (logger == null)
@@ -84,30 +74,6 @@ namespace Microsoft.Net.Http.Server
             else
             {
                 logger.LogError(location + "; " + message);
-            }
-        }
-
-        private class NullLogger : ILogger
-        {
-            public IDisposable BeginScope<TState>(TState state)
-            {
-                return new NullDispose();
-            }
-
-            public bool IsEnabled(LogLevel logLevel)
-            {
-                return false;
-            }
-
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
-            {
-            }
-
-            private class NullDispose : IDisposable
-            {
-                public void Dispose()
-                {
-                }
             }
         }
     }

--- a/src/Microsoft.Net.Http.Server/NativeInterop/UrlGroup.cs
+++ b/src/Microsoft.Net.Http.Server/NativeInterop/UrlGroup.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Net.Http.Server
         internal void SetProperty(HttpApi.HTTP_SERVER_PROPERTY property, IntPtr info, uint infosize, bool throwOnError = true)
         {            
             Debug.Assert(info != IntPtr.Zero, "SetUrlGroupProperty called with invalid pointer");
-            
+            CheckDisposed();
+
             var statusCode = HttpApi.HttpSetUrlGroupProperty(Id, property, info, infosize);
 
             if (statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS)
@@ -67,6 +68,7 @@ namespace Microsoft.Net.Http.Server
         internal void RegisterPrefix(string uriPrefix, int contextId)
         {
             LogHelper.LogInfo(_logger, "Listening on prefix: " + uriPrefix);
+            CheckDisposed();
 
             var statusCode = HttpApi.HttpAddUrlToUrlGroup(Id, uriPrefix, (ulong)contextId, 0);
 
@@ -86,6 +88,7 @@ namespace Microsoft.Net.Http.Server
         internal bool UnregisterPrefix(string uriPrefix)
         {
             LogHelper.LogInfo(_logger, "Stop listening on prefix: " + uriPrefix);
+            CheckDisposed();
 
             var statusCode = HttpApi.HttpRemoveUrlFromUrlGroup(Id, uriPrefix, 0);
 
@@ -114,6 +117,14 @@ namespace Microsoft.Net.Http.Server
                 LogHelper.LogError(_logger, "CleanupV2Config", "Result: " + statusCode);
             }
             Id = 0;
+        }
+
+        private void CheckDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(this.GetType().FullName);
+            }
         }
     }
 }

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/Request.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/Request.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Net.Http.Server
                 QueryString = Marshal.PtrToStringUni((IntPtr)cookedUrl.pQueryString, cookedUrl.QueryStringLength / 2);
             }
 
-            var prefix = requestContext.Server.UrlPrefixes.GetPrefix((int)memoryBlob.RequestBlob->UrlContext);
+            var prefix = requestContext.Server.Settings.UrlPrefixes.GetPrefix((int)memoryBlob.RequestBlob->UrlContext);
             var originalPath = RequestUriBuilder.GetRequestPath(RawUrl, cookedUrlPath, RequestContext.Logger);
 
             // These paths are both unescaped already.

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/Response.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/Response.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Net.Http.Server
             _expectedBodyLength = 0;
             _nativeStream = null;
             _cacheTtl = null;
-            _authChallenges = RequestContext.Server.AuthenticationManager.AuthenticationSchemes;
+            _authChallenges = RequestContext.Server.Settings.Authentication.Schemes;
         }
 
         private enum ResponseState
@@ -412,7 +412,7 @@ namespace Microsoft.Net.Http.Server
             // 401
             if (StatusCode == (ushort)HttpStatusCode.Unauthorized)
             {
-                RequestContext.Server.AuthenticationManager.SetAuthenticationChallenge(RequestContext);
+                RequestContext.Server.Settings.Authentication.SetAuthenticationChallenge(RequestContext);
             }
 
             var flags = HttpApi.HTTP_FLAGS.NONE;

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/ResponseStream.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/ResponseStream.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Net.Http.Server
                                 IntPtr.Zero);
                     }
 
-                    if (_requestContext.Server.IgnoreWriteExceptions)
+                    if (_requestContext.Server.Settings.IgnoreWriteExceptions)
                     {
                         statusCode = UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS;
                     }
@@ -338,7 +338,7 @@ namespace Microsoft.Net.Http.Server
             if (statusCode != ErrorCodes.ERROR_SUCCESS && statusCode != ErrorCodes.ERROR_IO_PENDING)
             {
                 asyncResult.Dispose();
-                if (_requestContext.Server.IgnoreWriteExceptions && started)
+                if (_requestContext.Server.Settings.IgnoreWriteExceptions && started)
                 {
                     asyncResult.Complete();
                 }
@@ -602,7 +602,7 @@ namespace Microsoft.Net.Http.Server
             if (statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS && statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_IO_PENDING)
             {
                 asyncResult.Dispose();
-                if (_requestContext.Server.IgnoreWriteExceptions && started)
+                if (_requestContext.Server.Settings.IgnoreWriteExceptions && started)
                 {
                     asyncResult.Complete();
                 }

--- a/src/Microsoft.Net.Http.Server/WebListenerSettings.cs
+++ b/src/Microsoft.Net.Http.Server/WebListenerSettings.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+// WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF
+// TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR
+// NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing
+// permissions and limitations under the License.
+
+using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions.Internal;
+
+namespace Microsoft.Net.Http.Server
+{
+    public class WebListenerSettings
+    {
+        private const long DefaultRequestQueueLength = 1000; // Http.sys default.
+
+        // The native request queue
+        private long _requestQueueLength = DefaultRequestQueueLength;
+        private RequestQueue _requestQueue;
+        private ILogger _logger = NullLogger.Instance;
+
+        public WebListenerSettings()
+        {
+        }
+
+        /// <summary>
+        /// The logger that will be used to create the WebListener instance. This should not be changed
+        /// after creating the listener.
+        /// </summary>
+        public ILogger Logger
+        {
+            get { return _logger; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+                _logger = value;
+            }
+        }
+
+        /// <summary>
+        /// The url prefixes to register with Http.Sys. These may be modified at any time prior to disposing
+        /// the listener.
+        /// </summary>
+        public UrlPrefixCollection UrlPrefixes { get; } = new UrlPrefixCollection();
+
+        /// <summary>
+        /// Http.Sys authentication settings. These may be modified at any time prior to disposing
+        /// the listener.
+        /// </summary>
+        public AuthenticationManager Authentication { get; } = new AuthenticationManager();
+
+        /// <summary>
+        /// Exposes the Http.Sys timeout configurations.  These may also be configured in the registry.
+        /// These may be modified at any time prior to disposing the listener.
+        /// </summary>
+        public TimeoutManager Timeouts { get; } = new TimeoutManager();
+
+
+        // TODO: https://github.com/aspnet/WebListener/issues/173
+        /// <summary>
+        /// Gets or Sets if response body writes that fail due to client disconnects should throw exceptions or
+        /// complete normally. The default is true.
+        /// </summary>
+        internal bool IgnoreWriteExceptions { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the maximum number of requests that will be queued up in Http.Sys.
+        /// </summary>
+        public long RequestQueueLimit
+        {
+            get
+            {
+                return _requestQueueLength;
+            }
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Empty);
+                }
+
+                if (_requestQueue != null)
+                {
+                    _requestQueue.SetLengthLimit(_requestQueueLength);
+                }
+                // Only store it if it succeeds or hasn't started yet
+                _requestQueueLength = value;
+            }
+        }
+
+        internal void SetRequestQueueLimit(RequestQueue requestQueue)
+        {
+            _requestQueue = requestQueue;
+            if (_requestQueueLength != DefaultRequestQueueLength)
+            {
+                _requestQueue.SetLengthLimit(_requestQueueLength);
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/RequestTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.AspNetCore.Server.WebListener
 
             foreach (string path in new[] { "/", "/11", "/2/3", "/2", "/11/2" })
             {
-                server.Listener.UrlPrefixes.Add(UrlPrefix.Create(rootUri.Scheme, rootUri.Host, rootUri.Port, path));
+                server.Listener.Settings.UrlPrefixes.Add(UrlPrefix.Create(rootUri.Scheme, rootUri.Host, rootUri.Port, path));
             }
 
             server.Start(new DummyApplication(app));

--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ServerTests.cs
@@ -256,8 +256,8 @@ namespace Microsoft.AspNetCore.Server.WebListener
             using (Utilities.CreateHttpServer(out address, httpContext => Task.FromResult(0))) { }
 
             var server = new MessagePump(Options.Create(new WebListenerOptions()), new LoggerFactory());
-            server.Listener.UrlPrefixes.Add(UrlPrefix.Create(address));
-            server.Listener.SetRequestQueueLimit(1001);
+            server.Listener.Settings.UrlPrefixes.Add(UrlPrefix.Create(address));
+            server.Listener.Settings.RequestQueueLimit = 1001;
 
             using (server)
             {

--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/Utilities.cs
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/Utilities.cs
@@ -67,8 +67,8 @@ namespace Microsoft.AspNetCore.Server.WebListener
 
                     var server = new MessagePump(Options.Create(new WebListenerOptions()), new LoggerFactory());
                     server.Features.Get<IServerAddressesFeature>().Addresses.Add(baseAddress);
-                    server.Listener.AuthenticationManager.AuthenticationSchemes = authType;
-                    server.Listener.AuthenticationManager.AllowAnonymous = allowAnonymous;
+                    server.Listener.Settings.Authentication.Schemes = authType;
+                    server.Listener.Settings.Authentication.AllowAnonymous = allowAnonymous;
                     try
                     {
                         server.Start(new DummyApplication(app));

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/RequestTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Net.Http.Server
                 var uriBuilder = new UriBuilder(root);
                 foreach (string path in new[] { "/", "/11", "/2/3", "/2", "/11/2" })
                 {
-                    server.UrlPrefixes.Add(UrlPrefix.Create(uriBuilder.Scheme, uriBuilder.Host, uriBuilder.Port, path));
+                    server.Settings.UrlPrefixes.Add(UrlPrefix.Create(uriBuilder.Scheme, uriBuilder.Host, uriBuilder.Port, path));
                 }
                 server.Start();
 

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/ServerTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/ServerTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                server.SetRequestQueueLimit(1001);
+                server.Settings.RequestQueueLimit = 1001;
                 var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
@@ -199,7 +199,7 @@ namespace Microsoft.Net.Http.Server
                 Assert.Equal(string.Empty, response);
 
                 address += "pathbase/";
-                server.UrlPrefixes.Add(address);
+                server.Settings.UrlPrefixes.Add(address);
 
                 responseTask = SendRequestAsync(address);
 
@@ -220,7 +220,7 @@ namespace Microsoft.Net.Http.Server
             using (var server = Utilities.CreateHttpServer(out address))
             {
                 address += "pathbase/";
-                server.UrlPrefixes.Add(address);
+                server.Settings.UrlPrefixes.Add(address);
                 var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
@@ -231,7 +231,7 @@ namespace Microsoft.Net.Http.Server
                 var response = await responseTask;
                 Assert.Equal(string.Empty, response);
 
-                Assert.True(server.UrlPrefixes.Remove(address));
+                Assert.True(server.Settings.UrlPrefixes.Remove(address));
 
                 responseTask = SendRequestAsync(address);
 

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/Utilities.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/Utilities.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Net.Http.Server
         internal static WebListener CreateHttpAuthServer(AuthenticationSchemes authScheme, bool allowAnonymos, out string baseAddress)
         {
             var listener = CreateHttpServer(out baseAddress);
-            listener.AuthenticationManager.AuthenticationSchemes = authScheme;
-            listener.AuthenticationManager.AllowAnonymous = allowAnonymos;
+            listener.Settings.Authentication.Schemes = authScheme;
+            listener.Settings.Authentication.AllowAnonymous = allowAnonymos;
             return listener;
         }
 
@@ -45,7 +45,7 @@ namespace Microsoft.Net.Http.Server
                     root = prefix.Scheme + "://" + prefix.Host + ":" + prefix.Port;
                     baseAddress = prefix.ToString();
                     var listener = new WebListener();
-                    listener.UrlPrefixes.Add(prefix);
+                    listener.Settings.UrlPrefixes.Add(prefix);
                     try
                     {
                         listener.Start();
@@ -61,7 +61,6 @@ namespace Microsoft.Net.Http.Server
             throw new Exception("Failed to locate a free port.");
         }
 
-
         internal static WebListener CreateHttpsServer()
         {
             return CreateServer("https", "localhost", 9090, string.Empty);
@@ -70,7 +69,7 @@ namespace Microsoft.Net.Http.Server
         internal static WebListener CreateServer(string scheme, string host, int port, string path)
         {
             WebListener listener = new WebListener();
-            listener.UrlPrefixes.Add(UrlPrefix.Create(scheme, host, port, path));
+            listener.Settings.UrlPrefixes.Add(UrlPrefix.Create(scheme, host, port, path));
             listener.Start();
             return listener;
         }


### PR DESCRIPTION
@davidfowl @DamianEdwards @JunTaoLuo @muratg @halter73 

Note all settings can be configured before and after creating / starting the listener (except the logger).
