### PR TITLE
Ignore write failures by default

### DIFF
--- a/src/Microsoft.Net.Http.Server/LogHelper.cs
+++ b/src/Microsoft.Net.Http.Server/LogHelper.cs
@@ -53,6 +53,18 @@ namespace Microsoft.Net.Http.Server
             }
         }
 
+        internal static void LogDebug(ILogger logger, string location, Exception exception)
+        {
+            if (logger == null)
+            {
+                Debug.WriteLine(exception);
+            }
+            else
+            {
+                logger.LogDebug(0, exception, location);
+            }
+        }
+
         internal static void LogException(ILogger logger, string location, Exception exception)
         {
             if (logger == null)
@@ -61,7 +73,7 @@ namespace Microsoft.Net.Http.Server
             }
             else
             {
-                logger.LogError(location, exception);
+                logger.LogError(0, exception, location);
             }
         }
 

--- a/src/Microsoft.Net.Http.Server/WebListenerSettings.cs
+++ b/src/Microsoft.Net.Http.Server/WebListenerSettings.cs
@@ -69,13 +69,11 @@ namespace Microsoft.Net.Http.Server
         /// </summary>
         public TimeoutManager Timeouts { get; } = new TimeoutManager();
 
-
-        // TODO: https://github.com/aspnet/WebListener/issues/173
         /// <summary>
         /// Gets or Sets if response body writes that fail due to client disconnects should throw exceptions or
-        /// complete normally. The default is true.
+        /// complete normally. The default is false.
         /// </summary>
-        internal bool IgnoreWriteExceptions { get; set; } = true;
+        public bool ThrowWriteExceptions { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of requests that will be queued up in Http.Sys.

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/ResponseBodyTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/ResponseBodyTests.cs
@@ -8,7 +8,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.Net.Http.Server
@@ -21,14 +20,14 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 context.Response.Body.Write(new byte[10], 0, 10);
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 Assert.Equal(new Version(1, 1), response.Version);
                 IEnumerable<string> ignored;
@@ -44,7 +43,7 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 context.Response.Body.Write(new byte[10], 0, 10);
@@ -52,7 +51,7 @@ namespace Microsoft.Net.Http.Server
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 IEnumerable<string> contentLength;
                 Assert.False(response.Content.Headers.TryGetValues("content-length", out contentLength), "Content-Length");
@@ -67,7 +66,7 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 context.Response.Headers["transfeR-Encoding"] = "CHunked";
@@ -76,7 +75,7 @@ namespace Microsoft.Net.Http.Server
                 await stream.WriteAsync(responseBytes, 0, responseBytes.Length);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 Assert.Equal(new Version(1, 1), response.Version);
                 IEnumerable<string> ignored;
@@ -92,11 +91,11 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 context.Response.Headers["Content-lenGth"] = " 30 ";
-                Stream stream = context.Response.Body;
+                var stream = context.Response.Body;
 #if NET451
                 stream.EndWrite(stream.BeginWrite(new byte[10], 0, 10, null, null));
 #else
@@ -106,7 +105,7 @@ namespace Microsoft.Net.Http.Server
                 await stream.WriteAsync(new byte[10], 0, 10);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 Assert.Equal(new Version(1, 1), response.Version);
                 IEnumerable<string> contentLength;
@@ -123,7 +122,7 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 context.Response.Headers["Content-lenGth"] = " 20 ";
@@ -144,7 +143,7 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 context.Response.Headers["Content-lenGth"] = " 20 ";
@@ -161,7 +160,7 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 context.Response.Headers["Content-lenGth"] = " 10 ";
@@ -179,7 +178,7 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 context.Response.Headers["Content-lenGth"] = " 10 ";
@@ -204,7 +203,7 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 context.Response.Body.Write(new byte[10], 0, 0);
@@ -212,7 +211,7 @@ namespace Microsoft.Net.Http.Server
                 await context.Response.Body.WriteAsync(new byte[10], 0, 0);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 Assert.Equal(new Version(1, 1), response.Version);
                 IEnumerable<string> ignored;
@@ -228,7 +227,7 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 var cts = new CancellationTokenSource();
@@ -237,7 +236,7 @@ namespace Microsoft.Net.Http.Server
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 Assert.Equal(new byte[20], await response.Content.ReadAsByteArrayAsync());
             }
@@ -249,29 +248,30 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 var cts = new CancellationTokenSource();
-                cts.CancelAfter(TimeSpan.FromSeconds(1));
+                cts.CancelAfter(TimeSpan.FromSeconds(10));
                 // First write sends headers
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 Assert.Equal(new byte[20], await response.Content.ReadAsByteArrayAsync());
             }
         }
 
         [Fact]
-        public async Task ResponseBody_FirstWriteAsyncWithCanceledCancellationToken_CancelsButDoesNotAbort()
+        public async Task ResponseBodyWriteExceptions_FirstWriteAsyncWithCanceledCancellationToken_CancelsAndAborts()
         {
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                server.Settings.ThrowWriteExceptions = true;
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 var cts = new CancellationTokenSource();
@@ -280,20 +280,57 @@ namespace Microsoft.Net.Http.Server
                 var writeTask = context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
                 Assert.True(writeTask.IsCanceled);
                 context.Dispose();
-
-                HttpResponseMessage response = await responseTask;
-                Assert.Equal(200, (int)response.StatusCode);
-                Assert.Equal(new byte[0], await response.Content.ReadAsByteArrayAsync());
+#if NET451
+                // .NET 4.5 HttpClient automatically retries a request if it does not get a response.
+                context = await server.AcceptAsync();
+                cts = new CancellationTokenSource();
+                cts.Cancel();
+                // First write sends headers
+                writeTask = context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
+                Assert.True(writeTask.IsCanceled);
+                context.Dispose();
+#endif
+                await Assert.ThrowsAsync<HttpRequestException>(() => responseTask);
             }
         }
 
         [Fact]
-        public async Task ResponseBody_SecondWriteAsyncWithCanceledCancellationToken_CancelsButDoesNotAbort()
+        public async Task ResponseBody_FirstWriteAsyncWithCanceledCancellationToken_CancelsAndAborts()
         {
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
+
+                var context = await server.AcceptAsync();
+                var cts = new CancellationTokenSource();
+                cts.Cancel();
+                // First write sends headers
+                var writeTask = context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
+                Assert.True(writeTask.IsCanceled);
+                context.Dispose();
+#if NET451
+                // .NET 4.5 HttpClient automatically retries a request if it does not get a response.
+                context = await server.AcceptAsync();
+                cts = new CancellationTokenSource();
+                cts.Cancel();
+                // First write sends headers
+                writeTask = context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
+                Assert.True(writeTask.IsCanceled);
+                context.Dispose();
+#endif
+                await Assert.ThrowsAsync<HttpRequestException>(() => responseTask);
+            }
+        }
+
+        [Fact]
+        public async Task ResponseBodyWriteExceptions_SecondWriteAsyncWithCanceledCancellationToken_CancelsAndAborts()
+        {
+            string address;
+            using (var server = Utilities.CreateHttpServer(out address))
+            {
+                server.Settings.ThrowWriteExceptions = true;
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 var cts = new CancellationTokenSource();
@@ -304,17 +341,272 @@ namespace Microsoft.Net.Http.Server
                 Assert.True(writeTask.IsCanceled);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
-                Assert.Equal(200, (int)response.StatusCode);
-                Assert.Equal(new byte[10], await response.Content.ReadAsByteArrayAsync());
+                await Assert.ThrowsAsync<HttpRequestException>(() => responseTask);
             }
         }
 
-        private async Task<HttpResponseMessage> SendRequestAsync(string uri)
+        [Fact]
+        public async Task ResponseBody_SecondWriteAsyncWithCanceledCancellationToken_CancelsAndAborts()
+        {
+            string address;
+            using (var server = Utilities.CreateHttpServer(out address))
+            {
+                var responseTask = SendRequestAsync(address);
+
+                var context = await server.AcceptAsync();
+                var cts = new CancellationTokenSource();
+                // First write sends headers
+                await context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
+                cts.Cancel();
+                var writeTask = context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
+                Assert.True(writeTask.IsCanceled);
+                context.Dispose();
+
+                await Assert.ThrowsAsync<HttpRequestException>(() => responseTask);
+            }
+        }
+
+        [Fact]
+        public async Task ResponseBodyWriteExceptions_ClientDisconnectsBeforeFirstWrite_WriteThrows()
+        {
+            string address;
+            using (var server = Utilities.CreateHttpServer(out address))
+            {
+                server.Settings.ThrowWriteExceptions = true;
+                var cts = new CancellationTokenSource();
+                var responseTask = SendRequestAsync(address, cts.Token);
+
+                var context = await server.AcceptAsync();
+                // First write sends headers
+                cts.Cancel();
+                await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+                Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
+                Assert.Throws<IOException>(() =>
+                {
+                    // It can take several tries before Write notices the disconnect.
+                    for (int i = 0; i < 1000; i++)
+                    {
+                        context.Response.Body.Write(new byte[1000], 0, 1000);
+                    }
+                });
+
+                Assert.Throws<ObjectDisposedException>(() => context.Response.Body.Write(new byte[1000], 0, 1000));
+
+                context.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task ResponseBodyWriteExceptions_ClientDisconnectsBeforeFirstWriteAsync_WriteThrows()
+        {
+            string address;
+            using (var server = Utilities.CreateHttpServer(out address))
+            {
+                server.Settings.ThrowWriteExceptions = true;
+                var cts = new CancellationTokenSource();
+                var responseTask = SendRequestAsync(address, cts.Token);
+
+                var context = await server.AcceptAsync();
+
+                // First write sends headers
+                cts.Cancel();
+                await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+
+                Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
+                await Assert.ThrowsAsync<IOException>(async () =>
+                {
+                    // It can take several tries before Write notices the disconnect.
+                    for (int i = 0; i < 1000; i++)
+                    {
+                        await context.Response.Body.WriteAsync(new byte[1000], 0, 1000);
+                    }
+                });
+
+                await Assert.ThrowsAsync<ObjectDisposedException>(() => context.Response.Body.WriteAsync(new byte[1000], 0, 1000));
+
+                context.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task ResponseBody_ClientDisconnectsBeforeFirstWrite_WriteCompletesSilently()
+        {
+            string address;
+            using (var server = Utilities.CreateHttpServer(out address))
+            {
+                var cts = new CancellationTokenSource();
+                var responseTask = SendRequestAsync(address, cts.Token);
+
+                var context = await server.AcceptAsync();
+                // First write sends headers
+                cts.Cancel();
+                await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+                Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
+                // It can take several tries before Write notices the disconnect.
+                for (int i = 0; i < 100; i++)
+                {
+                    context.Response.Body.Write(new byte[1000], 0, 1000);
+                }
+                context.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task ResponseBody_ClientDisconnectsBeforeFirstWriteAsync_WriteCompletesSilently()
+        {
+            string address;
+            using (var server = Utilities.CreateHttpServer(out address))
+            {
+                var cts = new CancellationTokenSource();
+                var responseTask = SendRequestAsync(address, cts.Token);
+
+                var context = await server.AcceptAsync();
+                // First write sends headers
+                cts.Cancel();
+                await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+                Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
+                // It can take several tries before Write notices the disconnect.
+                for (int i = 0; i < 100; i++)
+                {
+                    await context.Response.Body.WriteAsync(new byte[1000], 0, 1000);
+                }
+                context.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task ResponseBodyWriteExceptions_ClientDisconnectsBeforeSecondWrite_WriteThrows()
+        {
+            string address;
+            using (var server = Utilities.CreateHttpServer(out address))
+            {
+                server.Settings.ThrowWriteExceptions = true;
+                RequestContext context;
+                using (var client = new HttpClient())
+                {
+                    var responseTask = client.GetAsync(address, HttpCompletionOption.ResponseHeadersRead);
+
+                    context = await server.AcceptAsync();
+                    // First write sends headers
+                    context.Response.Body.Write(new byte[10], 0, 10);
+
+                    var response = await responseTask;
+                    response.EnsureSuccessStatusCode();
+                    response.Dispose();
+                }
+
+                Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
+                Assert.Throws<IOException>(() =>
+                {
+                    // It can take several tries before Write notices the disconnect.
+                    for (int i = 0; i < 100; i++)
+                    {
+                        context.Response.Body.Write(new byte[1000], 0, 1000);
+                    }
+                });
+                context.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task ResponseBodyWriteExceptions_ClientDisconnectsBeforeSecondWriteAsync_WriteThrows()
+        {
+            string address;
+            using (var server = Utilities.CreateHttpServer(out address))
+            {
+                server.Settings.ThrowWriteExceptions = true;
+                RequestContext context;
+                using (var client = new HttpClient())
+                {
+                    var responseTask = client.GetAsync(address, HttpCompletionOption.ResponseHeadersRead);
+
+                    context = await server.AcceptAsync();
+                    // First write sends headers
+                    await context.Response.Body.WriteAsync(new byte[10], 0, 10);
+
+                    var response = await responseTask;
+                    response.EnsureSuccessStatusCode();
+                    response.Dispose();
+                }
+
+                Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
+                await Assert.ThrowsAsync<IOException>(async () =>
+                {
+                    // It can take several tries before Write notices the disconnect.
+                    for (int i = 0; i < 100; i++)
+                    {
+                        await context.Response.Body.WriteAsync(new byte[1000], 0, 1000);
+                    }
+                });
+                context.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task ResponseBody_ClientDisconnectsBeforeSecondWrite_WriteCompletesSilently()
+        {
+            string address;
+            using (var server = Utilities.CreateHttpServer(out address))
+            {
+                RequestContext context;
+                using (var client = new HttpClient())
+                {
+                    var responseTask = client.GetAsync(address, HttpCompletionOption.ResponseHeadersRead);
+
+                    context = await server.AcceptAsync();
+                    // First write sends headers
+                    context.Response.Body.Write(new byte[10], 0, 10);
+
+                    var response = await responseTask;
+                    response.EnsureSuccessStatusCode();
+                    response.Dispose();
+                }
+
+                Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
+                // It can take several tries before Write notices the disconnect.
+                for (int i = 0; i < 10; i++)
+                {
+                    context.Response.Body.Write(new byte[1000], 0, 1000);
+                }
+                context.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task ResponseBody_ClientDisconnectsBeforeSecondWriteAsync_WriteCompletesSilently()
+        {
+            string address;
+            using (var server = Utilities.CreateHttpServer(out address))
+            {
+                RequestContext context;
+                using (var client = new HttpClient())
+                {
+                    var responseTask = client.GetAsync(address, HttpCompletionOption.ResponseHeadersRead);
+
+                    context = await server.AcceptAsync();
+                    // First write sends headers
+                    await context.Response.Body.WriteAsync(new byte[10], 0, 10);
+
+                    var response = await responseTask;
+                    response.EnsureSuccessStatusCode();
+                    response.Dispose();
+                }
+                
+                Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
+                // It can take several tries before Write notices the disconnect.
+                for (int i = 0; i < 10; i++)
+                {
+                    await context.Response.Body.WriteAsync(new byte[1000], 0, 1000);
+                }
+                context.Dispose();
+            }
+        }
+
+        private async Task<HttpResponseMessage> SendRequestAsync(string uri, CancellationToken cancellationToken = new CancellationToken())
         {
             using (HttpClient client = new HttpClient())
             {
-                return await client.GetAsync(uri);
+                return await client.GetAsync(uri, cancellationToken);
             }
         }
     }


### PR DESCRIPTION
#173 @halter73 @davidfowl @muratg

Similar to the policy we applied to Kestrel.
1. Don't throw exceptions from the response stream for failed writes. Complete silently or throw a Operation/TaskCancelledException if a tripped CancellationToken was passed in.
2. Log these failures as Debug.

The lower level WebListener (and HttpListener) already had this IgnoreWriteExceptions feature, it just needed to be turned on and fine tuned.
