### PR TITLE
Reorder SendFileAsync to match Write/FlushAsync

### DIFF
--- a/src/Microsoft.Net.Http.Server/Helpers.cs
+++ b/src/Microsoft.Net.Http.Server/Helpers.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -79,6 +80,17 @@ namespace Microsoft.Net.Http.Server
                 }
             }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
             return tcs.Task;
+        }
+
+        internal static ArraySegment<byte> GetChunkHeader(long size)
+        {
+            if (size < int.MaxValue)
+            {
+                return GetChunkHeader((int)size);
+            }
+
+            // Greater than 2gb, perf is no longer our concern
+            return new ArraySegment<byte>(Encoding.ASCII.GetBytes(size.ToString("X") + "\r\n"));
         }
 
         /// <summary>

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/RequestContext.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/RequestContext.cs
@@ -308,11 +308,12 @@ namespace Microsoft.Net.Http.Server
             // TODO: Verbose log
             try
             {
-                if (_requestAbortSource != null)
-                {
-                    _requestAbortSource.Dispose();
-                }
+                _requestAbortSource?.Dispose();
                 Response.Dispose();
+            }
+            catch
+            {
+                Abort();
             }
             finally
             {
@@ -334,14 +335,19 @@ namespace Microsoft.Net.Http.Server
                 {
                     _requestAbortSource.Cancel();
                 }
+                catch (ObjectDisposedException)
+                {
+                }
                 catch (Exception ex)
                 {
-                    LogHelper.LogException(Logger, "Abort", ex);
+                    LogHelper.LogDebug(Logger, "Abort", ex);
                 }
                 _requestAbortSource.Dispose();
             }
             ForceCancelRequest();
             Request.Dispose();
+            // Only Abort, Response.Dispose() tries a graceful flush
+            Response.Abort();
         }
 
         private static void Abort(object state)

--- a/src/Microsoft.Net.Http.Server/RequestProcessing/Response.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/Response.cs
@@ -109,7 +109,6 @@ namespace Microsoft.Net.Http.Server
         {
             get
             {
-                CheckDisposed();
                 EnsureResponseStream();
                 return _nativeStream;
             }
@@ -243,6 +242,12 @@ namespace Microsoft.Net.Http.Server
                 CheckResponseStarted();
                 _cacheTtl = value;
             }
+        }
+
+        internal void Abort()
+        {
+            // Update state for HasStarted. Do not attempt a graceful Dispose.
+            _responseState = ResponseState.Closed;
         }
 
         // should only be called from RequestContext
@@ -682,14 +687,6 @@ namespace Microsoft.Net.Http.Server
             if (errorCode != ErrorCodes.ERROR_SUCCESS)
             {
                 throw new WebListenerException((int)errorCode);
-            }
-        }
-
-        private void CheckDisposed()
-        {
-            if (_responseState >= ResponseState.Closed)
-            {
-                throw new ObjectDisposedException(GetType().FullName);
             }
         }
 

--- a/src/Microsoft.Net.Http.Server/WebListener.cs
+++ b/src/Microsoft.Net.Http.Server/WebListener.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Net.Http.Server
         // returned from HttpReceiveClientCertificate when using the 
         // FileCompletionNotificationModes.SkipCompletionPortOnSuccess flag.
         // This bug was only hit when the buffer passed into HttpReceiveClientCertificate
-        // (1500 bytes initially) is tool small for the certificate.
+        // (1500 bytes initially) is too small for the certificate.
         // Due to this bug in downlevel operating systems the FileCompletionNotificationModes.SkipCompletionPortOnSuccess
         // flag is only used on Win8 and later.
         internal static readonly bool SkipIOCPCallbackOnSuccess = ComNetOS.IsWin8orLater;

--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ResponseSendFileTests.cs
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ResponseSendFileTests.cs
@@ -221,12 +221,14 @@ namespace Microsoft.AspNetCore.Server.WebListener
             using (Utilities.CreateHttpServer(out address, async httpContext =>
             {
                 var sendFile = httpContext.Features.Get<IHttpSendFileFeature>();
-                await sendFile.SendFileAsync(AbsoluteFilePath, 1234567, null, CancellationToken.None);
+                await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+                    sendFile.SendFileAsync(AbsoluteFilePath, 1234567, null, CancellationToken.None));
                 completed = true;
             }))
             {
-                await Assert.ThrowsAsync<HttpRequestException>(() => SendRequestAsync(address));
-                Assert.False(completed);
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.True(completed);
             }
         }
 
@@ -238,12 +240,14 @@ namespace Microsoft.AspNetCore.Server.WebListener
             using (Utilities.CreateHttpServer(out address, async httpContext =>
             {
                 var sendFile = httpContext.Features.Get<IHttpSendFileFeature>();
-                await sendFile.SendFileAsync(AbsoluteFilePath, 0, 1234567, CancellationToken.None);
+                await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+                    sendFile.SendFileAsync(AbsoluteFilePath, 0, 1234567, CancellationToken.None));
                 completed = true;
             }))
             {
-                await Assert.ThrowsAsync<HttpRequestException>(() => SendRequestAsync(address));
-                Assert.False(completed);
+                var response = await SendRequestAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.True(completed);
             }
         }
 

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/ResponseSendFileTests.cs
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/ResponseSendFileTests.cs
@@ -30,14 +30,15 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 await Assert.ThrowsAsync<FileNotFoundException>(() => 
                     context.Response.SendFileAsync("Missing.txt", 0, null, CancellationToken.None));
                 context.Dispose();
                 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
+                response.EnsureSuccessStatusCode();
             }
         }
         
@@ -47,13 +48,13 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 IEnumerable<string> ignored;
                 Assert.False(response.Content.Headers.TryGetValues("content-length", out ignored), "Content-Length");
@@ -68,13 +69,13 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 await context.Response.SendFileAsync(RelativeFilePath, 0, null, CancellationToken.None);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 IEnumerable<string> ignored;
                 Assert.False(response.Content.Headers.TryGetValues("content-length", out ignored), "Content-Length");
@@ -89,13 +90,13 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 IEnumerable<string> contentLength;
                 Assert.False(response.Content.Headers.TryGetValues("content-length", out contentLength), "Content-Length");
@@ -110,14 +111,14 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 IEnumerable<string> contentLength;
                 Assert.False(response.Content.Headers.TryGetValues("content-length", out contentLength), "Content-Length");
@@ -132,13 +133,13 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, FileLength / 2, CancellationToken.None);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 IEnumerable<string> contentLength;
                 Assert.False(response.Content.Headers.TryGetValues("content-length", out contentLength), "Content-Length");
@@ -153,14 +154,15 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
                     () => context.Response.SendFileAsync(AbsoluteFilePath, 1234567, null, CancellationToken.None));
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
+                response.EnsureSuccessStatusCode();
             }
         }
 
@@ -170,14 +172,15 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
                     () => context.Response.SendFileAsync(AbsoluteFilePath, 0, 1234567, CancellationToken.None));
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
+                response.EnsureSuccessStatusCode();
             }
         }
 
@@ -187,13 +190,13 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, 0, CancellationToken.None);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 IEnumerable<string> contentLength;
                 Assert.False(response.Content.Headers.TryGetValues("content-length", out contentLength), "Content-Length");
@@ -212,7 +215,7 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 await context.Response.SendFileAsync(emptyFilePath, 0, null, CancellationToken.None);
@@ -221,7 +224,7 @@ namespace Microsoft.Net.Http.Server
                 context.Dispose();
                 File.Delete(emptyFilePath);
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 IEnumerable<string> contentLength;
                 Assert.False(response.Content.Headers.TryGetValues("content-length", out contentLength), "Content-Length");
@@ -236,13 +239,13 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 context.Response.Headers["Content-lenGth"] = FileLength.ToString();
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 IEnumerable<string> contentLength;
                 Assert.True(response.Content.Headers.TryGetValues("content-length", out contentLength), "Content-Length");
@@ -258,14 +261,14 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 context.Response.Headers["Content-lenGth"] = "10";
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, 10, CancellationToken.None);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 IEnumerable<string> contentLength;
                 Assert.True(response.Content.Headers.TryGetValues("content-length", out contentLength), "Content-Length");
@@ -281,14 +284,14 @@ namespace Microsoft.Net.Http.Server
             string address;
             using (var server = Utilities.CreateHttpServer(out address))
             {
-                Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
+                var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync();
                 context.Response.Headers["Content-lenGth"] = "0";
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, 0, CancellationToken.None);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 IEnumerable<string> contentLength;
                 Assert.True(response.Content.Headers.TryGetValues("content-length", out contentLength), "Content-Length");
@@ -313,7 +316,7 @@ namespace Microsoft.Net.Http.Server
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, cts.Token);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 Assert.Equal(FileLength * 2, (await response.Content.ReadAsByteArrayAsync()).Length);
             }
@@ -335,7 +338,7 @@ namespace Microsoft.Net.Http.Server
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, cts.Token);
                 context.Dispose();
 
-                HttpResponseMessage response = await responseTask;
+                var response = await responseTask;
                 Assert.Equal(200, (int)response.StatusCode);
                 Assert.Equal(FileLength * 2, (await response.Content.ReadAsByteArrayAsync()).Length);
             }


### PR DESCRIPTION
Cleanup from https://github.com/aspnet/WebListener/pull/227

Fixing the order of operations in SendFileAsync to match WriteAsync/FlushAsync. E.g. do all of the validation before calling ComputeLeftToWrite. Otherwise you end up in a state where ComputeLeftToWrite has computed and locked the response headers, but they don't get sent.

@halter73 @BrennanConroy 
