### PR TITLE
Revert buffer alignment in NativeRequestContext

### DIFF
--- a/src/Microsoft.Net.Http.Server/RequestProcessing/NativeRequestContext.cs
+++ b/src/Microsoft.Net.Http.Server/RequestProcessing/NativeRequestContext.cs
@@ -132,10 +132,18 @@ namespace Microsoft.Net.Http.Server
             _nativeOverlapped = new SafeNativeOverlapped(boundHandle,
                 boundHandle.AllocateNativeOverlapped(AsyncAcceptContext.IOCallback, _acceptResult, _backingBuffer));
 
-            // HttpReceiveHttpRequest expects the request pointer to be 8-byte-aligned or it fails. On ARM
-            // CLR creates buffers that are 4-byte-aligned so we need force 8-byte alignment.
             var requestAddress = Marshal.UnsafeAddrOfPinnedArrayElement(_backingBuffer, 0);
-            _bufferAlignment = (int)(requestAddress.ToInt64() & 0x07);
+
+            // TODO:
+            // Apparently the HttpReceiveHttpRequest memory alignment requirements for non - ARM processors
+            // are different than for ARM processors. We have seen 4 - byte - aligned buffers allocated on
+            // virtual x64/x86 machines which were accepted by HttpReceiveHttpRequest without errors. In
+            // these cases the buffer alignment may cause reading values at invalid offset. Setting buffer
+            // alignment to 0 for now.
+            // 
+            // _bufferAlignment = (int)(requestAddress.ToInt64() & 0x07);
+
+            _bufferAlignment = 0;
 
             _nativeRequest = (HttpApi.HTTP_REQUEST*)(requestAddress + _bufferAlignment);
         }


### PR DESCRIPTION
The buffer alignment is used to ensure HttpReceivedHttpRequest works
properly on ARM. However the chance breaks the WebListener on various
virtual machine environments (we discoverred issue on Parallel + Win10 and
Hyper-v + Win7x86 so far).

The buffer alignment will be set to zero hence WebListener will work
properly in all environment except ARM.

/cc @Tratcher @moozzyk 
