### PR TITLE
Add a timeout for draining requests on shutdown

### DIFF
--- a/src/Microsoft.AspNetCore.Server.HttpSys/HttpSysOptions.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/HttpSysOptions.cs
@@ -81,6 +81,12 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
+        /// <summary>
+        /// The amount of time to wait for active requests to drain while the server is shutting down.
+        /// New requests will receive a 503 response in this time period. The default is 5 seconds.
+        /// </summary>
+        public TimeSpan ShutdownTimeout { get; set; } = TimeSpan.FromSeconds(5);
+
         internal void SetRequestQueueLimit(RequestQueue requestQueue)
         {
             _requestQueue = requestQueue;

--- a/src/Microsoft.AspNetCore.Server.HttpSys/MessagePump.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/MessagePump.cs
@@ -221,7 +221,15 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             if (_outstandingRequests > 0)
             {
                 LogHelper.LogInfo(_logger, "Stopping, waiting for " + _outstandingRequests + " request(s) to drain.");
-                _shutdownSignal.WaitOne();
+                var drained = _shutdownSignal.WaitOne(Listener.Options.ShutdownTimeout);
+                if (drained)
+                {
+                    LogHelper.LogInfo(_logger, "All requests drained successfully.");
+                }
+                else
+                {
+                    LogHelper.LogInfo(_logger, "Timed out, terminating " + _outstandingRequests + " request(s).");
+                }
             }
             // All requests are finished
             _listener.Dispose();


### PR DESCRIPTION
#298 
Using the same option name and default as Kestrel.