### PR TITLE
1.1.1 Patch - shutdown timeout

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,3 +1,6 @@
 {
-    "projects": ["src", "test"]
+    "projects": ["src", "test"],
+    "sdk": {
+      "version": "1.0.0-preview2-1-003177"
+    }
 }

--- a/samples/HelloWorld/project.json
+++ b/samples/HelloWorld/project.json
@@ -3,7 +3,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.Net.Http.Server": "1.1.0-*"
+    "Microsoft.Net.Http.Server": "1.1.1-*"
   },
   "commands": {
     "sample": "HelloWorld"

--- a/samples/HotAddSample/project.json
+++ b/samples/HotAddSample/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.AspNetCore.Server.WebListener": "1.1.0-*",
+    "Microsoft.AspNetCore.Server.WebListener": "1.1.1-*",
     "Microsoft.Extensions.Logging.Console": "1.1.0-*"
   },
   "buildOptions": {

--- a/samples/SelfHostServer/project.json
+++ b/samples/SelfHostServer/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.AspNetCore.Server.WebListener": "1.1.0-*",
+    "Microsoft.AspNetCore.Server.WebListener": "1.1.1-*",
     "Microsoft.Extensions.Logging.Console": "1.1.0-*"
   },
   "buildOptions": {

--- a/src/Microsoft.AspNetCore.Server.WebListener/project.json
+++ b/src/Microsoft.AspNetCore.Server.WebListener/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0-*",
+  "version": "1.1.1-*",
   "description": "ASP.NET Core HTTP server for Windows.",
   "packOptions": {
     "tags": [
@@ -14,7 +14,7 @@
       "type": "build"
     },
     "Microsoft.Net.Http.Headers": "1.1.0-*",
-    "Microsoft.Net.Http.Server": "1.1.0-*",
+    "Microsoft.Net.Http.Server": "1.1.1-*",
     "NETStandard.Library": "1.6.1-*"
   },
   "buildOptions": {

--- a/src/Microsoft.Net.Http.Server/project.json
+++ b/src/Microsoft.Net.Http.Server/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0-*",
+  "version": "1.1.1-*",
   "description": ".NET HTTP server that uses the Windows HTTP Server API.",
   "packOptions": {
     "tags": [

--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/ServerTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Server.WebListener
         }
 
         [ConditionalFact]
-        public async Task Server_ShutdownDurringRequest_Success()
+        public async Task Server_ShutdownDuringRequest_Success()
         {
             Task<string> responseTask;
             ManualResetEvent received = new ManualResetEvent(false);
@@ -86,6 +86,30 @@ namespace Microsoft.AspNetCore.Server.WebListener
             }
             string response = await responseTask;
             Assert.Equal("Hello World", response);
+        }
+
+        [ConditionalFact]
+        public async Task Server_ShutdownDuringLongRunningRequest_TimesOut()
+        {
+            Task<string> responseTask;
+            var received = new ManualResetEvent(false);
+            bool? shutdown = null;
+            var waitForShutdown = new ManualResetEvent(false);
+            string address;
+            using (Utilities.CreateHttpServer(out address, httpContext =>
+            {
+                received.Set();
+                shutdown = waitForShutdown.WaitOne(TimeSpan.FromSeconds(15));
+                httpContext.Response.ContentLength = 11;
+                return httpContext.Response.WriteAsync("Hello World");
+            }))
+            {
+                responseTask = SendRequestAsync(address);
+                Assert.True(received.WaitOne(TimeSpan.FromSeconds(10)));
+            }
+            Assert.False(shutdown.HasValue);
+            waitForShutdown.Set();
+            await Assert.ThrowsAsync<HttpRequestException>(async () => await responseTask);
         }
 
         [ConditionalFact]

--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/project.json
@@ -6,7 +6,7 @@
   "testRunner": "xunit",
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
-    "Microsoft.AspNetCore.Server.WebListener": "1.1.0-*",
+    "Microsoft.AspNetCore.Server.WebListener": "1.1.1-*",
     "Microsoft.AspNetCore.Testing": "1.1.0-*",
     "xunit": "2.2.0-*"
   },

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/project.json
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
     "Microsoft.AspNetCore.Testing": "1.1.0-*",
-    "Microsoft.Net.Http.Server": "1.1.0-*",
+    "Microsoft.Net.Http.Server": "1.1.1-*",
     "xunit": "2.2.0-*"
   },
   "frameworks": {

--- a/test/Microsoft.Net.Http.Server.Tests/project.json
+++ b/test/Microsoft.Net.Http.Server.Tests/project.json
@@ -2,7 +2,7 @@
   "testRunner": "xunit",
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
-    "Microsoft.Net.Http.Server": "1.1.0-*",
+    "Microsoft.Net.Http.Server": "1.1.1-*",
     "xunit": "2.2.0-*"
   },
   "frameworks": {


### PR DESCRIPTION
#301 Timeout graceful request draining after 5 seconds. No configuration API.
Also bumping the packages versions to 1.1.1.


Replaces https://github.com/aspnet/HttpSysServer/pull/304