### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/HttpsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/HttpsTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         private async Task<string> SendRequestAsync(string uri, 
             X509Certificate cert = null)
         {
-#if NET451
+#if NET452
             var handler = new WebRequestHandler();
 #else
             var handler = new WinHttpHandler();
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         private async Task<string> SendRequestAsync(string uri, string upload)
         {
-#if NET451
+#if NET452
             var handler = new WebRequestHandler();
 #else
             var handler = new WinHttpHandler();

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/HttpsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/HttpsTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         private async Task<string> SendRequestAsync(string uri, 
             X509Certificate cert = null)
         {
-#if NET451
+#if NET452
             WebRequestHandler handler = new WebRequestHandler();
 #else
             WinHttpHandler handler = new WinHttpHandler();
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
         private async Task<string> SendRequestAsync(string uri, string upload)
         {
-#if NET451
+#if NET452
             WebRequestHandler handler = new WebRequestHandler();
 #else
             WinHttpHandler handler = new WinHttpHandler();

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestBodyTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 Assert.Equal("Hello World", response);
             }
         }
-#if NET451
+#if NET452
         [ConditionalFact]
         public async Task RequestBody_ReadBeginEnd_Success()
         {

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseBodyTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 context.Response.Headers["Content-lenGth"] = " 30 ";
                 var stream = context.Response.Body;
-#if NET451
+#if NET452
                 stream.EndWrite(stream.BeginWrite(new byte[10], 0, 10, null, null));
 #else
                 await stream.WriteAsync(new byte[10], 0, 10);
@@ -282,7 +282,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var writeTask = context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
                 Assert.True(writeTask.IsCanceled);
                 context.Dispose();
-#if NET451
+#if NET452
                 // .NET 4.5 HttpClient automatically retries a request if it does not get a response.
                 context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 cts = new CancellationTokenSource();
@@ -311,7 +311,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var writeTask = context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
                 Assert.True(writeTask.IsCanceled);
                 context.Dispose();
-#if NET451
+#if NET452
                 // .NET 4.5 HttpClient automatically retries a request if it does not get a response.
                 context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 cts = new CancellationTokenSource();

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseSendFileTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseSendFileTests.cs
@@ -362,7 +362,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var writeTask = context.Response.SendFileAsync(AbsoluteFilePath, 0, null, cts.Token);
                 Assert.True(writeTask.IsCanceled);
                 context.Dispose();
-#if NET451
+#if NET452
                 // .NET 4.5 HttpClient automatically retries a request if it does not get a response.
                 context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 cts = new CancellationTokenSource();
@@ -391,7 +391,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var writeTask = context.Response.SendFileAsync(AbsoluteFilePath, 0, null, cts.Token);
                 Assert.True(writeTask.IsCanceled);
                 context.Dispose();
-#if NET451
+#if NET452
                 // .NET 4.5 HttpClient automatically retries a request if it does not get a response.
                 context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 cts = new CancellationTokenSource();

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/SkipOffDomainAttribute.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/SkipOffDomainAttribute.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 try
                 {
-#if NET451
+#if NET452
                     return !string.IsNullOrEmpty(System.DirectoryServices.ActiveDirectory.Domain.GetComputerDomain().Name);
 #endif
                 }

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/Utilities.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/Utilities.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         {
             var win8Version = new Version(6, 2);
 
-#if NET451
+#if NET452
             IsWin8orLater = (Environment.OSVersion.Version >= win8Version);
 #else
             IsWin8orLater = (new Version(RuntimeEnvironment.OperatingSystemVersion) >= win8Version);

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Server.HttpSys\Microsoft.AspNetCore.Server.HttpSys.csproj" />
@@ -10,7 +11,7 @@
     <PackageReference Include="xunit" Version="2.2.0-*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ResponseBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ResponseBodyTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 httpContext.Response.Headers["Content-lenGth"] = " 30 ";
                 Stream stream = httpContext.Response.Body;
-#if NET451
+#if NET452
                 stream.EndWrite(stream.BeginWrite(new byte[10], 0, 10, null, null));
 #else
                 await stream.WriteAsync(new byte[10], 0, 10);
@@ -221,7 +221,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 Assert.Equal(new byte[10], await response.Content.ReadAsByteArrayAsync());
             }
         }
-#if NET451
+#if NET452
         [ConditionalFact]
         public async Task ResponseBody_BeginWrite_TriggersOnStarting()
         {

--- a/test/Microsoft.AspNetCore.Server.HttpSys.Tests/Microsoft.AspNetCore.Server.HttpSys.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.Tests/Microsoft.AspNetCore.Server.HttpSys.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Server.HttpSys\Microsoft.AspNetCore.Server.HttpSys.csproj" />


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows