### PR TITLE
React to StringSegment change

### DIFF
--- a/src/Microsoft.AspNetCore.Server.HttpSys/FeatureContext.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/FeatureContext.cs
@@ -524,7 +524,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
             // We require 'public' and 's-max-age' or 'max-age' or the Expires header.
             CacheControlHeaderValue cacheControl;
-            if (CacheControlHeaderValue.TryParse(cacheControlHeader, out cacheControl) && cacheControl.Public)
+            if (CacheControlHeaderValue.TryParse(cacheControlHeader.ToString(), out cacheControl) && cacheControl.Public)
             {
                 if (cacheControl.SharedMaxAge.HasValue)
                 {


### PR DESCRIPTION
https://github.com/aspnet/HttpAbstractions/pull/844
There's an implicit converter from StringValues to string, but it doesn't work transitively with the converter from string to StringSegment. This is probably for the best because the StringValues to string converter may do string concats that we want to be aware of in a perf sensitive context.