### PR TITLE
Don't send chunked responses for HEAD requests

### DIFF
--- a/src/Microsoft.AspNetCore.Server.HttpSys/RequestProcessing/Response.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/RequestProcessing/Response.cs
@@ -384,9 +384,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 // The application is performing it's own chunking.
                 _boundaryType = BoundaryType.PassThrough;
             }
-            else if (endOfRequest && !(isHeadRequest && statusCanHaveBody)) // HEAD requests should always end without a body. Assume a GET response would have a body.
+            else if (endOfRequest)
             {
-                if (statusCanHaveBody)
+                if (!isHeadRequest && statusCanHaveBody)
                 {
                     Headers[HttpKnownHeaderNames.ContentLength] = Constants.Zero;
                 }


### PR DESCRIPTION
#339 
HEAD requests don't have response bodies, but they do emulate GET requests that may. HttpSysServer was assuming that the emulated GET request would result in a chunked response so it included the Transfer-Encoding: chunked header. However, it forgot to suppress the chunked terminator. This didn't show up in the tests because they weren't expecting additional data on the connection, and they also weren't re-using connections.

Rather than assuming chunking, it now omits the headers and pretends it's a content-length 0 response.