### PR TITLE
Add flag to disable synchronous IO

### DIFF
--- a/src/Microsoft.AspNetCore.Server.HttpSys/FeatureContext.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/FeatureContext.cs
@@ -29,7 +29,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         IHttpAuthenticationFeature,
         IHttpUpgradeFeature,
         IHttpRequestIdentifierFeature,
-        IHttpMaxRequestBodySizeFeature
+        IHttpMaxRequestBodySizeFeature,
+        IHttpBodyControlFeature
     {
         private RequestContext _requestContext;
         private IFeatureCollection _features;
@@ -462,6 +463,12 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 _traceIdentitfier = value;
                 SetInitialized(Fields.TraceIdentifier);
             }
+        }
+
+        bool IHttpBodyControlFeature.AllowSynchronousIO
+        {
+            get => _requestContext.AllowSynchronousIO;
+            set => _requestContext.AllowSynchronousIO = value;
         }
 
         bool IHttpMaxRequestBodySizeFeature.IsReadOnly => Request.HasRequestBodyStarted;

--- a/src/Microsoft.AspNetCore.Server.HttpSys/HttpSysOptions.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/HttpSysOptions.cs
@@ -131,6 +131,12 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value that controls whether synchronous IO is allowed for the HttpContext.Request.Body and HttpContext.Response.Body.
+        /// The default is `true`.
+        /// </summary>
+        public bool AllowSynchronousIO { get; set; } = true;
+
         internal void Apply(UrlGroup urlGroup, RequestQueue requestQueue)
         {
             _urlGroup = urlGroup;

--- a/src/Microsoft.AspNetCore.Server.HttpSys/RequestProcessing/Request.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/RequestProcessing/Request.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         // private byte[] _referredTokenBindingId;
 
         private BoundaryType _contentBoundaryType;
+
         private long? _contentLength;
         private RequestStream _nativeStream;
 
@@ -149,10 +150,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         {
             if (_nativeStream == null && HasEntityBody)
             {
-                _nativeStream = new RequestStream(RequestContext)
-                {
-                    MaxSize = RequestContext.Server.Options.MaxRequestBodySize
-                };
+                _nativeStream = new RequestStream(RequestContext);
             }
             return _nativeStream;
         }

--- a/src/Microsoft.AspNetCore.Server.HttpSys/RequestProcessing/RequestContext.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/RequestProcessing/RequestContext.cs
@@ -30,6 +30,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             _memoryBlob = memoryBlob;
             Request = new Request(this, _memoryBlob);
             Response = new Response(this);
+            AllowSynchronousIO = server.Options.AllowSynchronousIO;
         }
 
         internal HttpSysListener Server { get; }
@@ -87,6 +88,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         public bool IsUpgradableRequest => Request.IsUpgradable;
+
+        internal bool AllowSynchronousIO { get; set; }
 
         public Task<Stream> UpgradeAsync()
         {

--- a/src/Microsoft.AspNetCore.Server.HttpSys/RequestProcessing/RequestStream.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/RequestProcessing/RequestStream.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         internal RequestStream(RequestContext httpContext)
         {
             _requestContext = httpContext;
+            _maxSize = _requestContext.Server.Options.MaxRequestBodySize;
         }
 
         internal RequestContext RequestContext
@@ -111,6 +112,11 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         public override unsafe int Read([In, Out] byte[] buffer, int offset, int size)
         {
+            if (!RequestContext.AllowSynchronousIO)
+            {
+                throw new InvalidOperationException("Synchronous IO APIs are disabled, see AllowSynchronousIO.");
+            }
+
             ValidateReadBuffer(buffer, offset, size);
             CheckSizeLimit();
             if (_closed)

--- a/src/Microsoft.AspNetCore.Server.HttpSys/RequestProcessing/ResponseBody.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/RequestProcessing/ResponseBody.cs
@@ -91,10 +91,16 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         // Send headers
         public override void Flush()
         {
+            if (!RequestContext.AllowSynchronousIO)
+            {
+                throw new InvalidOperationException("Synchronous IO APIs are disabled, see AllowSynchronousIO.");
+            }
+
             if (_disposed)
             {
                 return;
             }
+
             FlushInternal(endOfRequest: false);
         }
 
@@ -449,9 +455,15 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         public override void Write(byte[] buffer, int offset, int count)
         {
+            if (!RequestContext.AllowSynchronousIO)
+            {
+                throw new InvalidOperationException("Synchronous IO APIs are disabled, see AllowSynchronousIO.");
+            }
+
             // Validates for null and bounds. Allows count == 0.
             // TODO: Verbose log parameters
             var data = new ArraySegment<byte>(buffer, offset, count);
+
             CheckDisposed();
 
             CheckWriteCount(count);

--- a/src/Microsoft.AspNetCore.Server.HttpSys/StandardFeatureCollection.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/StandardFeatureCollection.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             { typeof(IHttpRequestIdentifierFeature), _identityFunc },
             { typeof(RequestContext), ctx => ctx.RequestContext },
             { typeof(IHttpMaxRequestBodySizeFeature), _identityFunc },
+            { typeof(IHttpBodyControlFeature), _identityFunc },
         };
 
         private readonly FeatureContext _featureContext;

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/HttpsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/HttpsTests.cs
@@ -60,10 +60,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 string input = new StreamReader(context.Request.Body).ReadToEnd();
                 Assert.Equal("Hello World", input);
                 context.Response.ContentLength = 11;
-                using (var writer = new StreamWriter(context.Response.Body))
-                {
-                    writer.Write("Hello World");
-                }
+                var writer = new StreamWriter(context.Response.Body);
+                await writer.WriteAsync("Hello World");
+                await writer.FlushAsync();
 
                 string response = await responseTask;
                 Assert.Equal("Hello World", response);

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/OpaqueUpgradeTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/OpaqueUpgradeTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 byte[] body = Encoding.UTF8.GetBytes("Hello World");
-                context.Response.Body.Write(body, 0, body.Length);
+                await context.Response.Body.WriteAsync(body, 0, body.Length);
 
                 Assert.Throws<InvalidOperationException>(() => context.Response.Headers["Upgrade"] = "WebSocket"); // Win8.1 blocks anything but WebSocket
                 await Assert.ThrowsAsync<InvalidOperationException>(async () => await context.UpgradeAsync());

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseCachingTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseCachingTests.cs
@@ -324,7 +324,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.ContentLength = 10;
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
-                context.Response.Body.Write(new byte[10], 0, 10);
+                await context.Response.Body.WriteAsync(new byte[10], 0, 10);
                 // Http.Sys will add this for us
                 Assert.Null(context.Response.ContentLength);
                 context.Dispose();
@@ -381,6 +381,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
+                server.Options.AllowSynchronousIO = true;
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
@@ -418,8 +419,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
-                context.Response.Body.Write(new byte[10], 0, 10);
-                context.Response.Body.Flush();
+                await context.Response.Body.WriteAsync(new byte[10], 0, 10);
+                await context.Response.Body.FlushAsync();
                 context.Dispose();
 
                 var response = await responseTask;
@@ -453,7 +454,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.ContentLength = 10;
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
-                context.Response.Body.Write(new byte[10], 0, 10);
+                await context.Response.Body.WriteAsync(new byte[10], 0, 10);
                 // Http.Sys will add this for us
                 Assert.Null(context.Response.ContentLength);
                 context.Dispose();
@@ -999,7 +1000,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 context.Response.Headers["content-range"] = "bytes 0-10/100";
                 context.Response.ContentLength = 11;
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
-                context.Response.Body.Write(new byte[100], 0, 11);
+                await context.Response.Body.WriteAsync(new byte[100], 0, 11);
                 context.Dispose();
 
                 var response = await responseTask;
@@ -1016,7 +1017,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 context.Response.Headers["content-range"] = "bytes 0-10/100";
                 context.Response.ContentLength = 11;
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
-                context.Response.Body.Write(new byte[100], 0, 11);
+                await context.Response.Body.WriteAsync(new byte[100], 0, 11);
                 context.Dispose();
 
                 response = await responseTask;
@@ -1041,7 +1042,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.ContentLength = 100;
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
-                context.Response.Body.Write(new byte[100], 0, 100);
+                await context.Response.Body.WriteAsync(new byte[100], 0, 100);
                 context.Dispose();
 
                 var response = await responseTask;
@@ -1071,7 +1072,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.ContentLength = 100;
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
-                context.Response.Body.Write(new byte[100], 0, 100);
+                await context.Response.Body.WriteAsync(new byte[100], 0, 100);
                 context.Dispose();
 
                 var response = await responseTask;

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseHeaderTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseHeaderTests.cs
@@ -390,6 +390,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
+                server.Options.AllowSynchronousIO = true;
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 var responseHeaders = context.Response.Headers;
 

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ServerTests.cs
@@ -42,10 +42,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 context.Response.ContentLength = 11;
-                using (var writer = new StreamWriter(context.Response.Body))
-                {
-                    writer.Write("Hello World");
-                }
+                var writer = new StreamWriter(context.Response.Body);
+                await writer.WriteAsync("Hello World");
+                await writer.FlushAsync();
 
                 string response = await responseTask;
                 Assert.Equal("Hello World", response);
@@ -61,13 +60,12 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var responseTask = SendRequestAsync(address, "Hello World");
 
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout);
-                string input = new StreamReader(context.Request.Body).ReadToEnd();
+                var input = await new StreamReader(context.Request.Body).ReadToEndAsync();
                 Assert.Equal("Hello World", input);
                 context.Response.ContentLength = 11;
-                using (var writer = new StreamWriter(context.Response.Body))
-                {
-                    writer.Write("Hello World");
-                }
+                var writer = new StreamWriter(context.Response.Body);
+                await writer.WriteAsync("Hello World");
+                await writer.FlushAsync();
 
                 var response = await responseTask;
                 Assert.Equal("Hello World", response);
@@ -218,10 +216,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 context.Response.Headers["Connection"] = "close";
 
                 context.Response.ContentLength = 11;
-                using (var writer = new StreamWriter(context.Response.Body))
-                {
-                    writer.Write("Hello World");
-                }
+                var writer = new StreamWriter(context.Response.Body);
+                await writer.WriteAsync("Hello World");
+                await writer.FlushAsync();
 
                 Assert.True(canceled.WaitOne(interval), "Disconnected");
                 Assert.True(ct.IsCancellationRequested, "IsCancellationRequested");

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/OpaqueUpgradeTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/OpaqueUpgradeTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 Assert.True(feature.IsReadOnly);
                 Assert.Null(feature.MaxRequestBodySize);
                 Assert.Throws<InvalidOperationException>(() => feature.MaxRequestBodySize = 12);
-                Assert.Equal(15, stream.Read(new byte[15], 0, 15));
+                Assert.Equal(15, await stream.ReadAsync(new byte[15], 0, 15));
                 upgraded = true;
                 waitHandle.Set();
             }))
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 using (Stream stream = await SendOpaqueRequestAsync("GET", address))
                 {
                     stream.Write(new byte[15], 0, 15);
-                    Assert.True(waitHandle.WaitOne(TimeSpan.FromSeconds(1)), "Timed out");
+                    Assert.True(waitHandle.WaitOne(TimeSpan.FromSeconds(10)), "Timed out");
                     Assert.True(upgraded.HasValue, "Upgraded not set");
                     Assert.True(upgraded.Value, "Upgrade failed");
                 }

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestBodyLimitTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestBodyLimitTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             string address;
             using (Utilities.CreateHttpServer(out address, options => options.MaxRequestBodySize = 11, httpContext =>
             {
+                httpContext.Features.Get<IHttpBodyControlFeature>().AllowSynchronousIO = true;
                 var feature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
                 Assert.NotNull(feature);
                 Assert.False(feature.IsReadOnly);
@@ -86,6 +87,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             string address;
             using (Utilities.CreateHttpServer(out address, options => options.MaxRequestBodySize = 11, httpContext =>
             {
+                httpContext.Features.Get<IHttpBodyControlFeature>().AllowSynchronousIO = true;
                 var feature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
                 Assert.NotNull(feature);
                 Assert.False(feature.IsReadOnly);
@@ -151,6 +153,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             string address;
             using (Utilities.CreateHttpServer(out address, options => options.MaxRequestBodySize = 10, httpContext =>
             {
+                httpContext.Features.Get<IHttpBodyControlFeature>().AllowSynchronousIO = true;
                 var feature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
                 Assert.NotNull(feature);
                 Assert.False(feature.IsReadOnly);
@@ -220,6 +223,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             string address;
             using (Utilities.CreateHttpServer(out address, options => options.MaxRequestBodySize = 10, httpContext =>
             {
+                httpContext.Features.Get<IHttpBodyControlFeature>().AllowSynchronousIO = true;
                 var feature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
                 Assert.NotNull(feature);
                 Assert.False(feature.IsReadOnly);
@@ -290,6 +294,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             string address;
             using (Utilities.CreateHttpServer(out address, options => options.MaxRequestBodySize = 10, httpContext =>
             {
+                httpContext.Features.Get<IHttpBodyControlFeature>().AllowSynchronousIO = true;
                 var feature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
                 Assert.NotNull(feature);
                 Assert.False(feature.IsReadOnly);

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestBodyTests.cs
@@ -9,6 +9,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
@@ -23,6 +24,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             using (Utilities.CreateHttpServer(out address, httpContext =>
             {
                 byte[] input = new byte[100];
+                httpContext.Features.Get<IHttpBodyControlFeature>().AllowSynchronousIO = true;
                 int read = httpContext.Request.Body.Read(input, 0, input.Length);
                 httpContext.Response.ContentLength = read;
                 httpContext.Response.Body.Write(input, 0, read);
@@ -75,6 +77,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             string address;
             using (Utilities.CreateHttpServer(out address, httpContext =>
             {
+                httpContext.Features.Get<IHttpBodyControlFeature>().AllowSynchronousIO = true;
                 byte[] input = new byte[100];
                 Assert.Throws<ArgumentNullException>("buffer", () => httpContext.Request.Body.Read(null, 0, 1));
                 Assert.Throws<ArgumentOutOfRangeException>("offset", () => httpContext.Request.Body.Read(input, -1, 1));
@@ -99,6 +102,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             using (Utilities.CreateHttpServer(out address, httpContext =>
             {
                 byte[] input = new byte[10];
+                httpContext.Features.Get<IHttpBodyControlFeature>().AllowSynchronousIO = true;
                 int read = httpContext.Request.Body.Read(input, 0, input.Length);
                 Assert.Equal(5, read);
                 content.Block.Release();

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ResponseHeaderTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ResponseHeaderTests.cs
@@ -130,8 +130,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 var responseInfo = httpContext.Features.Get<IHttpResponseFeature>();
                 var responseHeaders = responseInfo.Headers;
                 responseHeaders["Connection"] = new string[] { "Close" };
-                httpContext.Response.Body.Flush(); // Http.Sys adds the Content-Length: header for us if we don't flush
-                return Task.FromResult(0);
+                return httpContext.Response.Body.FlushAsync(); // Http.Sys adds the Content-Length: header for us if we don't flush
             }))
             {
                 HttpResponseMessage response = await SendRequestAsync(address);
@@ -204,6 +203,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             string address;
             using (Utilities.CreateHttpServer(out address, httpContext =>
                 {
+                    httpContext.Features.Get<IHttpBodyControlFeature>().AllowSynchronousIO = true;
                     var responseInfo = httpContext.Features.Get<IHttpResponseFeature>();
                     var responseHeaders = responseInfo.Headers;
                     responseHeaders.Add("Custom1", new string[] { "value1a", "value1b" });

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ServerTests.cs
@@ -53,12 +53,12 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public async Task Server_EchoHelloWorld_Success()
         {
             string address;
-            using (Utilities.CreateHttpServer(out address, httpContext =>
+            using (Utilities.CreateHttpServer(out address, async httpContext =>
                 {
-                    string input = new StreamReader(httpContext.Request.Body).ReadToEnd();
+                    var input = await new StreamReader(httpContext.Request.Body).ReadToEndAsync();
                     Assert.Equal("Hello World", input);
                     httpContext.Response.ContentLength = 11;
-                    return httpContext.Response.WriteAsync("Hello World");
+                    await httpContext.Response.WriteAsync("Hello World");
                 }))
             {
                 string response = await SendRequestAsync(address, "Hello World");


### PR DESCRIPTION
#366 Read, Write, and Flush now throw by default. There's some debate on Flush because it breaks StreamWriter.Dispose().