### PR TITLE
Increase timeout in Server_ClientDisconnects_CallCanceled to mitigate test flakiness

### DIFF
--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ServerTests.cs
@@ -219,7 +219,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         [ConditionalFact]
         public async Task Server_ClientDisconnects_CallCanceled()
         {
-            TimeSpan interval = TimeSpan.FromSeconds(1);
+            TimeSpan interval = TimeSpan.FromSeconds(10);
             ManualResetEvent received = new ManualResetEvent(false);
             ManualResetEvent aborted = new ManualResetEvent(false);
             ManualResetEvent canceled = new ManualResetEvent(false);


### PR DESCRIPTION
CI link: http://aspnetci/project.html?tab=testDetails&projectId=XPlat&testNameId=-5004057257646002980&page=1

I could only repro it on a slow VM under load, and increasing the timeout interval seems to fix it.

cc @ryanbrandenburg 