### PR TITLE
Reorder request disposal due to logging.

### DIFF
--- a/src/Microsoft.AspNetCore.Server.HttpSys/MessagePump.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/MessagePump.cs
@@ -204,17 +204,18 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     {
                         await _application.ProcessRequestAsync(context).SupressContext();
                         await featureContext.OnResponseStart();
-                        requestContext.Dispose();
-                        _application.DisposeContext(context, null);
                     }
                     finally
                     {
                         await featureContext.OnCompleted();
                     }
+                    _application.DisposeContext(context, null);
+                    requestContext.Dispose();
                 }
                 catch (Exception ex)
                 {
                     LogHelper.LogException(_logger, "ProcessRequestAsync", ex);
+                    _application.DisposeContext(context, ex);
                     if (requestContext.Response.HasStarted)
                     {
                         requestContext.Abort();
@@ -225,7 +226,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                         requestContext.Response.Headers.Clear();
                         SetFatalResponse(requestContext, 500);
                     }
-                    _application.DisposeContext(context, ex);
                 }
                 finally
                 {


### PR DESCRIPTION
https://github.com/aspnet/Logging/issues/543#issuecomment-321907828
HttpSys current disposes objects in the wrong order. It disposes the lowest level first, then the HttpContext, and then it invokes the OnCompleted callbacks. This cases errors when logging accesses request inside of the HttpContext dispose or OnCompleted.  The new order is OnCompleted, HttpContext, and then low level structures. This mirrors Kestrel.

Note requestContext.Abort also calls Dispose.