### PR TITLE
Fix hang in SendFile tests

### DIFF
--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseSendFileTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseSendFileTests.cs
@@ -510,7 +510,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             }
         }
 
-        [ConditionalFact(Skip = "Tests hanging: https://github.com/aspnet/HttpSysServer/issues/270")]
+        [ConditionalFact]
         public async Task ResponseSendFileExceptions_ClientDisconnectsBeforeSecondSend_SendThrows()
         {
             string address;
@@ -524,10 +524,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                     context = await server.AcceptAsync(Utilities.DefaultTimeout);
                     // First write sends headers
-                    await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
+                    var sendFileTask = context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
 
                     var response = await responseTask;
                     response.EnsureSuccessStatusCode();
+                    // Drain data from the connection so that SendFileAsync can complete.
+                    var bufferTask = response.Content.LoadIntoBufferAsync();
+
+                    await sendFileTask;
                     response.Dispose();
                 }
 
@@ -544,7 +548,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             }
         }
 
-        [ConditionalFact(Skip = "Tests hanging: https://github.com/aspnet/WebListener/issues/270")]
+        [ConditionalFact]
         public async Task ResponseSendFile_ClientDisconnectsBeforeSecondSend_SendCompletesSilently()
         {
             string address;
@@ -557,10 +561,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                     context = await server.AcceptAsync(Utilities.DefaultTimeout);
                     // First write sends headers
-                    await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
+                    var sendFileTask = context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
 
                     var response = await responseTask;
                     response.EnsureSuccessStatusCode();
+                    // Drain data from the connection so that SendFileAsync can complete.
+                    var bufferTask = response.Content.LoadIntoBufferAsync();
+
+                    await sendFileTask;
                     response.Dispose();
                 }
 


### PR DESCRIPTION
#270 
These tests were only failing on Win7. Win7 apparently buffers less data so SendFileAsync was not completing. The fix is to have the client start consuming the data. The client won't finish/succeed because this is an abort test, but at least the server gets unblocked now.