### PR TITLE
Fix parsing error on urls without path.

### DIFF
--- a/shared/Microsoft.AspNetCore.HttpSys.Sources/RequestProcessing/RawUrlHelper.cs
+++ b/shared/Microsoft.AspNetCore.HttpSys.Sources/RequestProcessing/RawUrlHelper.cs
@@ -7,6 +7,8 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 {
     internal static class RawUrlHelper
     {
+        private static byte[] _emtpyByteArray = new byte[0];
+
         /// <summary>
         /// Find the segment of the URI byte array which represents the path.
         /// </summary>
@@ -39,7 +41,8 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     if (pathStartIndex == -1)
                     {
                         // e.g. for request lines like: 'GET http://myserver' (no final '/')
-                        pathStartIndex = raw.Length;
+                        // At this point we can return an empty path.
+                        return new ArraySegment<byte>(_emtpyByteArray);
                     }
                 }
                 else

--- a/shared/Microsoft.AspNetCore.HttpSys.Sources/RequestProcessing/RawUrlHelper.cs
+++ b/shared/Microsoft.AspNetCore.HttpSys.Sources/RequestProcessing/RawUrlHelper.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text;
 
 namespace Microsoft.AspNetCore.HttpSys.Internal
 {
     internal static class RawUrlHelper
     {
-        private static byte[] _emtpyByteArray = new byte[0];
+        private static byte[] _forwardSlashPath = Encoding.ASCII.GetBytes("/");
 
         /// <summary>
         /// Find the segment of the URI byte array which represents the path.
@@ -41,8 +42,8 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     if (pathStartIndex == -1)
                     {
                         // e.g. for request lines like: 'GET http://myserver' (no final '/')
-                        // At this point we can return an empty path.
-                        return new ArraySegment<byte>(_emtpyByteArray);
+                        // At this point we can return a path with a slash.
+                        return new ArraySegment<byte>(_forwardSlashPath);
                     }
                 }
                 else

--- a/shared/Microsoft.AspNetCore.HttpSys.Sources/RequestProcessing/RawUrlHelper.cs
+++ b/shared/Microsoft.AspNetCore.HttpSys.Sources/RequestProcessing/RawUrlHelper.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 {
     internal static class RawUrlHelper
     {
-        private static byte[] _forwardSlashPath = Encoding.ASCII.GetBytes("/");
+        private static readonly byte[] _forwardSlashPath = Encoding.ASCII.GetBytes("/");
 
         /// <summary>
         /// Find the segment of the URI byte array which represents the path.

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 // GET http://localhost:5001 HTTP/1.1
                 var responseTask = SendSocketRequestAsync(root, root);
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout);
-                Assert.Equal("", context.Request.Path);
+                Assert.Equal("/", context.Request.Path);
                 Assert.Equal(root, context.Request.RawUrl);
             }
         }

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestTests.cs
@@ -125,7 +125,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var responseTask = SendSocketRequestAsync(root, root);
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 Assert.Equal("/", context.Request.Path);
+                Assert.Equal("", context.Request.PathBase);
                 Assert.Equal(root, context.Request.RawUrl);
+                Assert.False(root.EndsWith("/")); // make sure root doesn't have a trailing slash
             }
         }
 

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestTests.cs
@@ -115,6 +115,21 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         }
 
         [ConditionalFact]
+        public async Task Request_FullUriInRequestLine_ParsesPath()
+        {
+            string root;
+            using (var server = Utilities.CreateHttpServerReturnRoot("/", out root))
+            {
+                // Send a HTTP request with the request line:
+                // GET http://localhost:5001 HTTP/1.1
+                var responseTask = SendSocketRequestAsync(root, root);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                Assert.Equal("", context.Request.Path);
+                Assert.Equal(root, context.Request.RawUrl);
+            }
+        }
+
+        [ConditionalFact]
         public async Task Request_OptionsStar_EmptyPath()
         {
             string root;

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestTests.cs
@@ -259,6 +259,25 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
+        [ConditionalFact]
+        public async Task Request_FullUriInRequestLine_ParsesPath()
+        {
+            string root;
+            using (var server = Utilities.CreateHttpServerReturnRoot("/", out root, httpContext =>
+            {
+                var requestInfo = httpContext.Features.Get<IHttpRequestFeature>();
+                Assert.Equal("", requestInfo.Path);
+                return Task.FromResult(0);
+            }))
+            {
+                // Send a HTTP request with the request line:
+                // GET http://localhost:5001 HTTP/1.1
+                var response = await SendSocketRequestAsync(root, root);
+                var responseStatusCode = response.Substring(9); // Skip "HTTP/1.1 "
+                Assert.Equal("200", responseStatusCode);
+            }
+        }
+
         [ConditionalTheory]
         // The test server defines these prefixes: "/", "/11", "/2/3", "/2", "/11/2"
         [InlineData("/", "", "/")]

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestTests.cs
@@ -266,7 +266,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             using (var server = Utilities.CreateHttpServerReturnRoot("/", out root, httpContext =>
             {
                 var requestInfo = httpContext.Features.Get<IHttpRequestFeature>();
-                Assert.Equal("", requestInfo.Path);
+                Assert.Equal("/", requestInfo.Path);
                 return Task.FromResult(0);
             }))
             {

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestTests.cs
@@ -262,30 +262,28 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         [ConditionalFact]
         public async Task Request_FullUriInRequestLine_ParsesPath()
         {
-            string root;
-            using (var server = Utilities.CreateHttpServerReturnRoot("/", out root, httpContext =>
+            using (var server = Utilities.CreateHttpServerReturnRoot("/", out var root, httpContext =>
             {
                 var requestInfo = httpContext.Features.Get<IHttpRequestFeature>();
                 Assert.Equal("/", requestInfo.Path);
                 Assert.Equal("", requestInfo.PathBase);
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }))
             {
                 // Send a HTTP request with the request line:
                 // GET http://localhost:5001 HTTP/1.1
                 var response = await SendSocketRequestAsync(root, root);
                 var responseStatusCode = response.Substring(9); // Skip "HTTP/1.1 "
-                Assert.Equal("200", responseStatusCode);
+                Assert.Equal(StatusCodes.Status200OK.ToString(), responseStatusCode);
             }
         }
 
         [ConditionalFact]
         public async Task Request_FullUriInRequestLineWithSlashesInQuery_BlockedByHttpSys()
         {
-            string root;
-            using (var server = Utilities.CreateHttpServerReturnRoot("/", out root, httpContext =>
+            using (var server = Utilities.CreateHttpServerReturnRoot("/", out var root, httpContext =>
             {
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }))
             {
                 // Send a HTTP request with the request line:
@@ -293,7 +291,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 // Should return a 400 as it is a client error
                 var response = await SendSocketRequestAsync(root, root + "?query=value/1/2");
                 var responseStatusCode = response.Substring(9); // Skip "HTTP/1.1 "
-                Assert.Equal("400", responseStatusCode);
+                Assert.Equal(StatusCodes.Status400BadRequest.ToString(), responseStatusCode);
             }
         }
 

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestTests.cs
@@ -267,6 +267,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 var requestInfo = httpContext.Features.Get<IHttpRequestFeature>();
                 Assert.Equal("/", requestInfo.Path);
+                Assert.Equal("", requestInfo.PathBase);
                 return Task.FromResult(0);
             }))
             {
@@ -275,6 +276,24 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 var response = await SendSocketRequestAsync(root, root);
                 var responseStatusCode = response.Substring(9); // Skip "HTTP/1.1 "
                 Assert.Equal("200", responseStatusCode);
+            }
+        }
+
+        [ConditionalFact]
+        public async Task Request_FullUriInRequestLineWithSlashesInQuery_BlockedByHttpSys()
+        {
+            string root;
+            using (var server = Utilities.CreateHttpServerReturnRoot("/", out root, httpContext =>
+            {
+                return Task.FromResult(0);
+            }))
+            {
+                // Send a HTTP request with the request line:
+                // GET http://localhost:5001?query=value/1/2 HTTP/1.1
+                // Should return a 400 as it is a client error
+                var response = await SendSocketRequestAsync(root, root + "?query=value/1/2");
+                var responseStatusCode = response.Substring(9); // Skip "HTTP/1.1 "
+                Assert.Equal("400", responseStatusCode);
             }
         }
 


### PR DESCRIPTION
Fix for #405. At this point there are no tests for the Internal namespace, hence I didn't add any for now. We should consider adding them in the future?