### PR TITLE
Dispose of the existing native context before creating a new one.

### DIFF
--- a/src/Microsoft.AspNetCore.Server.HttpSys/AsyncAcceptContext.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/AsyncAcceptContext.cs
@@ -184,6 +184,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal void AllocateNativeRequest(uint? size = null, ulong requestId = 0)
         {
+            _nativeRequestContext?.Dispose();
             //Debug.Assert(size != 0, "unexpected size");
 
             // We can't reuse overlapped objects


### PR DESCRIPTION
This is a regression in post-2.0 refactoring. It fails to dispose an object pinned via a native overlapped object so it stays rooted indefinitely.