### PR TITLE
New setting to enable Kernel response buffering

### DIFF
--- a/src/Microsoft.AspNetCore.Server.HttpSys/HttpSysOptions.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/HttpSysOptions.cs
@@ -62,6 +62,15 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public bool ThrowWriteExceptions { get; set; }
 
         /// <summary>
+        /// Enable buffering of response data in the Kernel.
+        /// It should be used by an application doing synchronous I/O or by an application doing asynchronous I/O with
+        /// no more than one outstanding write at a time, and can significantly improve throughput over high-latency connections.
+        /// Applications that use asynchronous I/O and that may have more than one send outstanding at a time should not use this flag.
+        /// Enabling this can results in higher CPU and memory usage by Http.Sys.
+        /// </summary>
+        public bool EnableKernelResponseBuffering { get; set; }
+
+        /// <summary>
         /// Gets or sets the maximum number of concurrent connections to accept, -1 for infinite, or null to
         /// use the machine wide setting from the registry. The default value is null.
         /// </summary>

--- a/src/Microsoft.AspNetCore.Server.HttpSys/RequestProcessing/ResponseBody.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/RequestProcessing/ResponseBody.cs
@@ -43,6 +43,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal bool ThrowWriteExceptions => RequestContext.Server.Options.ThrowWriteExceptions;
 
+        internal bool EnableKernelResponseBuffering => RequestContext.Server.Options.EnableKernelResponseBuffering;
+
         internal bool IsDisposed => _disposed;
 
         public override bool CanSeek
@@ -436,6 +438,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             else if (!endOfRequest && _leftToWrite != writeCount)
             {
                 flags |= HttpApiTypes.HTTP_FLAGS.HTTP_SEND_RESPONSE_FLAG_MORE_DATA;
+                if (EnableKernelResponseBuffering)
+                {
+                    flags |= HttpApiTypes.HTTP_FLAGS.HTTP_SEND_RESPONSE_FLAG_BUFFER_DATA;
+                }
             }
 
             // Update _leftToWrite now so we can queue up additional async writes.

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ResponseBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ResponseBodyTests.cs
@@ -38,6 +38,41 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
+        [ConditionalTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ResponseBody_WriteNoHeaders_SetsChunked_LargeBody(bool enableKernelBuffering)
+        {
+            const int WriteSize = 1024 * 1024;
+            const int NumWrites = 32;
+
+            string address;
+            using (Utilities.CreateHttpServer(
+                baseAddress: out address,
+                configureOptions: options => { options.EnableKernelResponseBuffering = enableKernelBuffering; },
+                app: async httpContext =>
+                {
+					httpContext.Features.Get<IHttpBodyControlFeature>().AllowSynchronousIO = true;
+                    for (int i = 0; i < NumWrites - 1; i++)
+                    {
+                        httpContext.Response.Body.Write(new byte[WriteSize], 0, WriteSize);
+                    }
+                    await httpContext.Response.Body.WriteAsync(new byte[WriteSize], 0, WriteSize);
+                }))
+            {
+                var response = await SendRequestAsync(address);
+                Assert.Equal(200, (int)response.StatusCode);
+                Assert.Equal(new Version(1, 1), response.Version);
+                IEnumerable<string> ignored;
+                Assert.False(response.Content.Headers.TryGetValues("content-length", out ignored), "Content-Length");
+                Assert.True(response.Headers.TransferEncodingChunked.HasValue, "Chunked");
+
+                var bytes = await response.Content.ReadAsByteArrayAsync();
+                Assert.Equal(WriteSize * NumWrites, bytes.Length);
+                Assert.True(bytes.All(b => b == 0));
+            }
+        }
+
         [ConditionalFact]
         public async Task ResponseBody_WriteNoHeadersAndFlush_DefaultsToChunked()
         {


### PR DESCRIPTION
This PR introduces a new setting `EnableKernelResponseBuffering` that causes the `ResponseStream` to pass the `HTTP_SEND_RESPONSE_FLAG_BUFFER_DATA` flag to Http.sys as appropriate when sending responses.

Non-scientific benchmarks show dramatic perf wins when the response stream is written to in small amounts at a time (e.g. as done by aspnet/proxy), especially for networks with long round trip times.

After this change, I can get consistently more than 18 MB/s when serving static files through a proxy (similar to aspnet/proxy), hosted on an Azure A4 VM.