### PR TITLE
React to new SocketHttpHandler

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,17 +4,17 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>2.1.0-preview2-15728</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationCorePackageVersion>2.1.0-preview2-30272</MicrosoftAspNetCoreAuthenticationCorePackageVersion>
-    <MicrosoftAspNetCoreHostingPackageVersion>2.1.0-preview2-30272</MicrosoftAspNetCoreHostingPackageVersion>
-    <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview2-30272</MicrosoftAspNetCoreTestingPackageVersion>
-    <MicrosoftExtensionsLoggingConsolePackageVersion>2.1.0-preview2-30272</MicrosoftExtensionsLoggingConsolePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationCorePackageVersion>2.1.0-preview2-30301</MicrosoftAspNetCoreAuthenticationCorePackageVersion>
+    <MicrosoftAspNetCoreHostingPackageVersion>2.1.0-preview2-30301</MicrosoftAspNetCoreHostingPackageVersion>
+    <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview2-30301</MicrosoftAspNetCoreTestingPackageVersion>
+    <MicrosoftExtensionsLoggingConsolePackageVersion>2.1.0-preview2-30301</MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
-    <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview2-26225-03</MicrosoftNETCoreApp21PackageVersion>
-    <MicrosoftNetHttpHeadersPackageVersion>2.1.0-preview2-30272</MicrosoftNetHttpHeadersPackageVersion>
+    <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview2-26308-01</MicrosoftNETCoreApp21PackageVersion>
+    <MicrosoftNetHttpHeadersPackageVersion>2.1.0-preview2-30301</MicrosoftNetHttpHeadersPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.0</MicrosoftNETTestSdkPackageVersion>
-    <MicrosoftWin32RegistryPackageVersion>4.5.0-preview2-26224-02</MicrosoftWin32RegistryPackageVersion>
-    <SystemNetHttpWinHttpHandlerPackageVersion>4.5.0-preview2-26224-02</SystemNetHttpWinHttpHandlerPackageVersion>
-    <SystemSecurityPrincipalWindowsPackageVersion>4.5.0-preview2-26224-02</SystemSecurityPrincipalWindowsPackageVersion>
+    <MicrosoftWin32RegistryPackageVersion>4.5.0-preview2-26308-02</MicrosoftWin32RegistryPackageVersion>
+    <SystemNetHttpWinHttpHandlerPackageVersion>4.5.0-preview2-26308-02</SystemNetHttpWinHttpHandlerPackageVersion>
+    <SystemSecurityPrincipalWindowsPackageVersion>4.5.0-preview2-26308-02</SystemSecurityPrincipalWindowsPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0-beta.1.build3945</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestBodyTests.cs
@@ -344,7 +344,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 content.Block.Release();
                 context.Dispose();
 
-                await Assert.ThrowsAsync<TaskCanceledException>(async () => await responseTask);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await responseTask);
             }
         }
 
@@ -421,6 +421,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             protected async override Task SerializeToStreamAsync(Stream stream, TransportContext context)
             {
                 await stream.WriteAsync(new byte[5], 0, 5);
+                await stream.FlushAsync();
                 await Block.WaitAsync();
                 await stream.WriteAsync(new byte[5], 0, 5);
             }

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseBodyTests.cs
@@ -427,7 +427,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 // First write sends headers
                 cts.Cancel();
-                await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
                 Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
                 Assert.Throws<IOException>(() =>
                 {
@@ -458,7 +458,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 // First write sends headers
                 cts.Cancel();
-                await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
 
                 Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
                 await Assert.ThrowsAsync<IOException>(async () =>
@@ -489,7 +489,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 // First write sends headers
                 cts.Cancel();
-                await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
                 Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
                 // It can take several tries before Write notices the disconnect.
                 for (int i = 0; i < Utilities.WriteRetryLimit; i++)
@@ -512,7 +512,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 // First write sends headers
                 cts.Cancel();
-                await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
                 Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
                 // It can take several tries before Write notices the disconnect.
                 for (int i = 0; i < Utilities.WriteRetryLimit; i++)

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseSendFileTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseSendFileTests.cs
@@ -468,7 +468,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 // First write sends headers
                 cts.Cancel();
-                await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
 
                 Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
                 await Assert.ThrowsAsync<IOException>(async () =>
@@ -499,7 +499,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout);
                 // First write sends headers
                 cts.Cancel();
-                await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
                 Assert.True(context.DisconnectToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)));
                 // It can take several tries before Send notices the disconnect.
                 for (int i = 0; i < Utilities.WriteRetryLimit; i++)

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ServerTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                     Assert.True(canceled.WaitOne(interval), "canceled");
                     Assert.True(ct.IsCancellationRequested, "IsCancellationRequested");
 
-                    await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
 
                     context.Dispose();
                 }
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                     var context = await server.AcceptAsync(Utilities.DefaultTimeout);
 
                     client.CancelPendingRequests();
-                    await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
 
                     var ct = context.DisconnectToken;
                     Assert.True(ct.CanBeCanceled, "CanBeCanceled");

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestBodyLimitTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestBodyLimitTests.cs
@@ -413,6 +413,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             protected async override Task SerializeToStreamAsync(Stream stream, TransportContext context)
             {
                 await stream.WriteAsync(new byte[10], 0, 10);
+                await stream.FlushAsync();
                 Assert.True(await Block.WaitAsync(TimeSpan.FromSeconds(10)));
                 await stream.WriteAsync(new byte[10], 0, 10);
             }

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/RequestBodyTests.cs
@@ -232,7 +232,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             protected async override Task SerializeToStreamAsync(Stream stream, TransportContext context)
             {
                 await stream.WriteAsync(new byte[5], 0, 5);
-                await Block.WaitAsync();
+                await stream.FlushAsync();
+                Assert.True(await Block.WaitAsync(TimeSpan.FromSeconds(10)));
                 await stream.WriteAsync(new byte[5], 0, 5);
             }
 


### PR DESCRIPTION
https://github.com/aspnet/Coherence-Signed/issues/792
Pre-emptivly making changes for when the new SocketsHttpHandler becomes the default in preview2. This addresses all but the known NTLM issue they have already fixed in a later build.

There are two types of changes here:
1. SocketsHttpHandler does not flush it's headers before it starts sending the body so body data may arrive in the same packet and get included to Http.Sys's Request data structure. Reads must check the request structure before reading from the network. This code path has had very little testing and made some assumptions that need updating. Before, if the pre-buffered data didn't fill the users read buffer it would issue a second read to the network. This change drops that second read in favor of completing immediately, which more closely matches what happens for normal reads when less data arrives than the user requested.

2. Canceling throws a OperationCanceledException instead of a TaskCanceledException (a derived type). We have to use ThrowsAnyAsync to allow derived types on some frameworks instead of exact matches.