### PR TITLE
#364 - Expose HTTP_503_RESPONSE_VERBOSITY option

### DIFF
--- a/src/Microsoft.AspNetCore.Server.HttpSys/Http503ResponseVerbosityLevel.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/Http503ResponseVerbosityLevel.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.HttpSys
+{
+    /// <summary>
+    /// Enum declaring the allowed values for the verbosity level when http.sys reject requests due to throttling.
+    /// </summary>
+    public enum Http503ResponseVerbosityLevel
+    {
+        /// <summary>
+        /// A 503 response is not sent; the connection is reset. This is the default HTTP Server API behavior.
+        /// </summary>
+        Basic,
+
+        /// <summary>
+        /// The HTTP Server API sends a 503 response with a "Service Unavailable" reason phrase.
+        /// </summary>
+        Limited,
+
+        /// <summary>
+        /// The HTTP Server API sends a 503 response with a detailed reason phrase. 
+        /// </summary>
+        Full
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.HttpSys/Http503VerbosityLevel .cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/Http503VerbosityLevel .cs
@@ -6,21 +6,21 @@ namespace Microsoft.AspNetCore.Server.HttpSys
     /// <summary>
     /// Enum declaring the allowed values for the verbosity level when http.sys reject requests due to throttling.
     /// </summary>
-    public enum Http503ResponseVerbosityLevel
+    public enum Http503VerbosityLevel : long
     {
         /// <summary>
         /// A 503 response is not sent; the connection is reset. This is the default HTTP Server API behavior.
         /// </summary>
-        Basic,
+        Basic = 0,
 
         /// <summary>
         /// The HTTP Server API sends a 503 response with a "Service Unavailable" reason phrase.
         /// </summary>
-        Limited,
+        Limited = 1,
 
         /// <summary>
         /// The HTTP Server API sends a 503 response with a detailed reason phrase. 
         /// </summary>
-        Full
+        Full = 2
     }
 }

--- a/src/Microsoft.AspNetCore.Server.HttpSys/HttpSysOptions.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/HttpSysOptions.cs
@@ -9,14 +9,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 {
     public class HttpSysOptions
     {
-        private const long DefaultRejectionVerbosityLevel = (long)Http503ResponseVerbosityLevel.Basic; // Http.sys default.
+        private const Http503VerbosityLevel DefaultRejectionVerbosityLevel = Http503VerbosityLevel.Basic; // Http.sys default.
         private const long DefaultRequestQueueLength = 1000; // Http.sys default.
         internal static readonly int DefaultMaxAccepts = 5 * Environment.ProcessorCount;
         // Matches the default maxAllowedContentLength in IIS (~28.6 MB)
         // https://www.iis.net/configreference/system.webserver/security/requestfiltering/requestlimits#005
         private const long DefaultMaxRequestBodySize = 30000000;
 
-        private long _rejectionVebosityLevel = DefaultRejectionVerbosityLevel;
+        private Http503VerbosityLevel _rejectionVebosityLevel = DefaultRejectionVerbosityLevel;
         // The native request queue
         private long _requestQueueLength = DefaultRequestQueueLength;
         private long? _maxConnections;
@@ -145,30 +145,30 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// queue limit is reached. The default in http.sys is "Basic" which means http.sys is just resetting the TCP connection. IIS uses Limited
         /// as its default behavior which will result in sending back a 503 - Service Unavailable back to the client.
         /// </summary>
-        public Http503ResponseVerbosityLevel Http503ResponseVerbosityLevel
+        public Http503VerbosityLevel Http503Verbosity
         {
             get
             {
-                return (Http503ResponseVerbosityLevel)_rejectionVebosityLevel;
+                return _rejectionVebosityLevel;
             }
             set
             {
-                if (value < Http503ResponseVerbosityLevel.Basic || value > Http503ResponseVerbosityLevel.Full)
+                if (value < Http503VerbosityLevel.Basic || value > Http503VerbosityLevel.Full)
                 {
                     string message = String.Format(
                         CultureInfo.InvariantCulture,
                         "The value must be one of the values defined in the '{0}' enum.",
-                        typeof(Http503ResponseVerbosityLevel).Name);
+                        typeof(Http503VerbosityLevel).Name);
 
                     throw new ArgumentOutOfRangeException(nameof(value), value, message);
                 }
 
                 if (_requestQueue != null)
                 {
-                    _requestQueue.SetRejectionVerbosity((long)value);
+                    _requestQueue.SetRejectionVerbosity(value);
                 }
                 // Only store it if it succeeds or hasn't started yet
-                _rejectionVebosityLevel = (long)value;
+                _rejectionVebosityLevel = value;
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.HttpSys/NativeInterop/RequestQueue.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/NativeInterop/RequestQueue.cs
@@ -99,6 +99,21 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
+        // The listener must be active for this to work.
+        internal unsafe void SetRejectionVerbosity(long verbosity)
+        {
+            CheckDisposed();
+
+            var result = HttpApi.HttpSetRequestQueueProperty(Handle,
+                HttpApiTypes.HTTP_SERVER_PROPERTY.HttpServer503VerbosityProperty,
+                new IntPtr((void*)&verbosity), (uint)Marshal.SizeOf<long>(), 0, IntPtr.Zero);
+
+            if (result != 0)
+            {
+                throw new HttpSysException((int)result);
+            }
+        }
+
         public void Dispose()
         {
             if (_disposed)

--- a/src/Microsoft.AspNetCore.Server.HttpSys/NativeInterop/RequestQueue.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/NativeInterop/RequestQueue.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         // The listener must be active for this to work.
-        internal unsafe void SetRejectionVerbosity(long verbosity)
+        internal unsafe void SetRejectionVerbosity(Http503VerbosityLevel verbosity)
         {
             CheckDisposed();
 

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ServerTests.cs
@@ -246,6 +246,23 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         }
 
         [ConditionalFact]
+        public async Task Server_SetRejectionVerbosityLevel_Success()
+        {
+            string address;
+            using (var server = Utilities.CreateHttpServer(out address))
+            {
+                server.Options.Http503ResponseVerbosityLevel = Http503ResponseVerbosityLevel.Limited;
+                var responseTask = SendRequestAsync(address);
+
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context.Dispose();
+
+                var response = await responseTask;
+                Assert.Equal(string.Empty, response);
+            }
+        }
+
+        [ConditionalFact]
         public async Task Server_HotAddPrefix_Success()
         {
             string address;

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ServerTests.cs
@@ -248,10 +248,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         [ConditionalFact]
         public async Task Server_SetRejectionVerbosityLevel_Success()
         {
-            string address;
-            using (var server = Utilities.CreateHttpServer(out address))
+            using (var server = Utilities.CreateHttpServer(out string address))
             {
-                server.Options.Http503ResponseVerbosityLevel = Http503ResponseVerbosityLevel.Limited;
+                server.Options.Http503Verbosity = Http503VerbosityLevel.Limited;
                 var responseTask = SendRequestAsync(address);
 
                 var context = await server.AcceptAsync(Utilities.DefaultTimeout);

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ServerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
@@ -299,7 +300,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
-        public async Task Server_SetRejectionVerbosityLevel_Success()
+        public async Task Server_SetHttp503VebosittHittingThrottle_Success()
         {
             // This is just to get a dynamic port
             string address;
@@ -307,13 +308,32 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
             var server = Utilities.CreatePump();
             server.Listener.Options.UrlPrefixes.Add(UrlPrefix.Create(address));
+            Assert.Null(server.Listener.Options.MaxConnections);
+            server.Listener.Options.MaxConnections = 3;
             server.Listener.Options.Http503Verbosity = Http503VerbosityLevel.Limited;
 
             using (server)
             {
                 await server.StartAsync(new DummyApplication(), CancellationToken.None);
-                string response = await SendRequestAsync(address);
-                Assert.Equal(string.Empty, response);
+
+                using (var client1 = await SendHungRequestAsync("GET", address))
+                using (var client2 = await SendHungRequestAsync("GET", address))
+                {
+                    using (var client3 = await SendHungRequestAsync("GET", address))
+                    {
+                        using (HttpClient client4 = new HttpClient())
+                        {
+                            // Maxed out, refuses connection should return 503
+                            HttpResponseMessage response = await client4.GetAsync(address);
+
+                            Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+                        }
+                    }
+
+                    // A connection has been closed, try again.
+                    string responseText = await SendRequestAsync(address);
+                    Assert.Equal(string.Empty, responseText);
+                }
             }
         }
 

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ServerTests.cs
@@ -307,7 +307,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
             var server = Utilities.CreatePump();
             server.Listener.Options.UrlPrefixes.Add(UrlPrefix.Create(address));
-            server.Listener.Options.Http503ResponseVerbosityLevel = Http503ResponseVerbosityLevel.Limited;
+            server.Listener.Options.Http503Verbosity = Http503VerbosityLevel.Limited;
 
             using (server)
             {

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/ServerTests.cs
@@ -299,6 +299,25 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
+        public async Task Server_SetRejectionVerbosityLevel_Success()
+        {
+            // This is just to get a dynamic port
+            string address;
+            using (Utilities.CreateHttpServer(out address, httpContext => Task.FromResult(0))) { }
+
+            var server = Utilities.CreatePump();
+            server.Listener.Options.UrlPrefixes.Add(UrlPrefix.Create(address));
+            server.Listener.Options.Http503ResponseVerbosityLevel = Http503ResponseVerbosityLevel.Limited;
+
+            using (server)
+            {
+                await server.StartAsync(new DummyApplication(), CancellationToken.None);
+                string response = await SendRequestAsync(address);
+                Assert.Equal(string.Empty, response);
+            }
+        }
+
+        [ConditionalFact]
         public void Server_SetConnectionLimitArgumentValidation_Success()
         {
             var server = Utilities.CreatePump();


### PR DESCRIPTION
Changes discussed offline with Chris earlier this morning to expose Http503ResponseVebosityLevel. Feature request tracked in the backlog already under: https://github.com/aspnet/HttpSysServer/issues/364
https://msdn.microsoft.com/en-us/library/windows/desktop/aa364509(v=vs.85).aspx

I am submitting this to get unblocked for the migration of our UniversalStore services from Owin/Katana + WebApi 2.0 to Asp.Net Core