### PR TITLE
Remove obsolete #if's

### DIFF
--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/AuthenticationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/AuthenticationTests.cs
@@ -40,8 +40,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 Assert.Empty(response.Headers.WwwAuthenticate);
             }
         }
-#if !NETCOREAPP2_0
-        // https://github.com/aspnet/ServerTests/issues/82
+
         [ConditionalTheory]
         [InlineData(AuthenticationSchemes.Negotiate)]
         [InlineData(AuthenticationSchemes.NTLM)]
@@ -107,7 +106,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 Assert.Equal("Negotiate, NTLM, basic", response.Headers.WwwAuthenticate.ToString(), StringComparer.OrdinalIgnoreCase);
             }
         }
-#endif
+
         [ConditionalTheory]
         [InlineData(AuthenticationSchemes.Negotiate)]
         [InlineData(AuthenticationSchemes.NTLM)]
@@ -238,8 +237,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
         }
-#if !NETCOREAPP2_0
-        // https://github.com/aspnet/ServerTests/issues/82
+
         [ConditionalTheory]
         [InlineData(AuthenticationSchemes.Negotiate)]
         [InlineData(AuthenticationSchemes.NTLM)]
@@ -329,7 +327,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 Assert.Equal(authTypeList.Count(), response.Headers.WwwAuthenticate.Count);
             }
         }
-#endif
+
         [ConditionalFact]
         public async Task AuthTypes_Forbid_Forbidden()
         {

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/AuthenticationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/AuthenticationTests.cs
@@ -40,8 +40,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 Assert.Empty(response.Headers.WwwAuthenticate);
             }
         }
-#if !NETCOREAPP2_0
-        // https://github.com/aspnet/ServerTests/issues/82
+
         [ConditionalTheory]
         [InlineData(AuthenticationSchemes.Negotiate)]
         [InlineData(AuthenticationSchemes.NTLM)]
@@ -111,7 +110,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 Assert.Equal("Negotiate, NTLM, basic", response.Headers.WwwAuthenticate.ToString(), StringComparer.OrdinalIgnoreCase);
             }
         }
-#endif
+
         [ConditionalTheory]
         [InlineData(AuthenticationSchemes.Negotiate)]
         [InlineData(AuthenticationSchemes.NTLM)]


### PR DESCRIPTION
Following up on https://github.com/aspnet/ServerTests/issues/82, this is no longer relevant since we moved to 2.1/2.2 which has a new implementation of HttpClient.