### PR TITLE
Add diagnostics to debug flaky tests

### DIFF
--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/AuthenticationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/AuthenticationTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.NotNull(context.User);
                 Assert.False(context.User.Identity.IsAuthenticated);
                 Assert.Equal(authType, context.Response.AuthenticationChallenges);
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.NotNull(context.User);
                 Assert.False(context.User.Identity.IsAuthenticated);
                 Assert.Equal(authType, context.Response.AuthenticationChallenges);
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.NotNull(context.User);
                 Assert.False(context.User.Identity.IsAuthenticated);
                 Assert.Equal(authType, context.Response.AuthenticationChallenges);
@@ -124,14 +124,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address, useDefaultCredentials: true);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.NotNull(context.User);
                 Assert.False(context.User.Identity.IsAuthenticated);
                 Assert.Equal(authType, context.Response.AuthenticationChallenges);
                 context.Response.StatusCode = 401;
                 context.Dispose();
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.NotNull(context.User);
                 Assert.True(context.User.Identity.IsAuthenticated);
                 Assert.Equal(authType, context.Response.AuthenticationChallenges);
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address, useDefaultCredentials: true);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.NotNull(context.User);
                 Assert.True(context.User.Identity.IsAuthenticated);
                 Assert.Equal(authType, context.Response.AuthenticationChallenges);
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address, useDefaultCredentials: true);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.NotNull(context.User);
                 Assert.True(context.User.Identity.IsAuthenticated);
                 Assert.Equal(AuthenticationSchemes.Kerberos, context.Response.AuthenticationChallenges);
@@ -193,7 +193,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.NotNull(context.User);
                 Assert.False(context.User.Identity.IsAuthenticated);
                 Assert.Equal(AuthenticationSchemes.Kerberos, context.Response.AuthenticationChallenges);

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/HttpsTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/HttpsTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(Address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Dispose();
 
                 string response = await responseTask;
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(Address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] body = Encoding.UTF8.GetBytes("Hello World");
                 context.Response.ContentLength = body.Length;
                 await context.Response.Body.WriteAsync(body, 0, body.Length);
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(Address, "Hello World");
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 string input = new StreamReader(context.Request.Body).ReadToEnd();
                 Assert.Equal("Hello World", input);
                 context.Response.ContentLength = 11;
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(Address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cert = await context.Request.GetClientCertificateAsync();
                 Assert.Null(cert);
                 context.Dispose();
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 Assert.NotNull(clientCert);
                 Task<string> responseTask = SendRequestAsync(Address, clientCert);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cert = await context.Request.GetClientCertificateAsync();
                 Assert.NotNull(cert);
                 context.Dispose();

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/OpaqueUpgradeTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/OpaqueUpgradeTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> clientTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(clientTask);
                 byte[] body = Encoding.UTF8.GetBytes("Hello World");
                 await context.Response.Body.WriteAsync(body, 0, body.Length);
 

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestBodyTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 Assert.True(server.Options.AllowSynchronousIO);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[100];
 
                 Assert.True(context.AllowSynchronousIO);
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 Task<string> responseTask = SendRequestAsync(address, "Hello World");
 
                 server.Options.AllowSynchronousIO = true;
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[100];
                 int read = context.Request.Body.Read(input, 0, input.Length);
                 context.Response.ContentLength = read;
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(address, "Hello World");
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[100];
                 int read = await context.Request.Body.ReadAsync(input, 0, input.Length);
                 context.Response.ContentLength = read;
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(address, "Hello World");
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[100];
                 int read = context.Request.Body.EndRead(context.Request.Body.BeginRead(input, 0, input.Length, null, null));
                 context.Response.ContentLength = read;
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 Task<string> responseTask = SendRequestAsync(address, "Hello World");
 
                 server.Options.AllowSynchronousIO = true;
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[100];
                 Assert.Throws<ArgumentNullException>("buffer", () => context.Request.Body.Read(null, 0, 1));
                 Assert.Throws<ArgumentOutOfRangeException>("offset", () => context.Request.Body.Read(input, -1, 1));
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 Task<string> responseTask = SendRequestAsync(address, content);
 
                 server.Options.AllowSynchronousIO = true;
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[10];
                 int read = context.Request.Body.Read(input, 0, input.Length);
                 Assert.Equal(5, read);
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(address, content);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[10];
                 int read = await context.Request.Body.ReadAsync(input, 0, input.Length);
                 Assert.Equal(5, read);
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendSocketRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[11];
                 int read = await context.Request.Body.ReadAsync(input, 0, input.Length);
                 Assert.Equal(10, read);
@@ -206,7 +206,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(address, "Hello World");
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
                 byte[] input = new byte[10];
                 var cts = new CancellationTokenSource();
@@ -231,7 +231,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(address, content);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[10];
                 var cts = new CancellationTokenSource();
                 int read = await context.Request.Body.ReadAsync(input, 0, input.Length, cts.Token);
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(address, content);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[10];
                 var cts = new CancellationTokenSource();
                 cts.CancelAfter(TimeSpan.FromSeconds(5));
@@ -280,7 +280,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(address, content);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[10];
                 var cts = new CancellationTokenSource();
                 int read = await context.Request.Body.ReadAsync(input, 0, input.Length, cts.Token);
@@ -305,7 +305,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(address, content);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[10];
                 var cts = new CancellationTokenSource();
                 int read = await context.Request.Body.ReadAsync(input, 0, input.Length, cts.Token);
@@ -333,7 +333,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var client = new HttpClient();
                 var responseTask = client.PostAsync(address, content);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 byte[] input = new byte[10];
                 int read = await context.Request.Body.ReadAsync(input, 0, input.Length, context.DisconnectToken);
                 Assert.False(context.DisconnectToken.IsCancellationRequested);

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestHeaderTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestHeaderTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var requestHeaders = context.Request.Headers;
                 // NOTE: The System.Net client only sends the Connection: keep-alive header on the first connection per service-point.
                 // Assert.Equal(2, requestHeaders.Count);

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/RequestTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(root + "/basepath/SomePath?SomeQuery");
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
                 // General fields
                 var request = context.Request;
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(root + requestPath);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
                 // General fields
                 var request = context.Request;
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             using (var server = Utilities.CreateHttpServerReturnRoot("/", out root))
             {
                 var responseTask = SendSocketRequestAsync(root, "/%252F");
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.Equal("/%2F", context.Request.Path);
             }
         }
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 // Send a HTTP request with the request line:
                 // GET http://localhost:5001 HTTP/1.1
                 var responseTask = SendSocketRequestAsync(root, root);
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.Equal("/", context.Request.Path);
                 Assert.Equal("", context.Request.PathBase);
                 Assert.Equal(root, context.Request.RawUrl);
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             using (var server = Utilities.CreateHttpServerReturnRoot("/", out root))
             {
                 var responseTask = SendSocketRequestAsync(root, "*", "OPTIONS");
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.Equal("", context.Request.PathBase);
                 Assert.Equal("", context.Request.Path);
                 Assert.Equal("*", context.Request.RawUrl);
@@ -177,7 +177,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 Task<string> responseTask = SendRequestAsync(root + requestUri);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var request = context.Request;
 
                 Assert.Equal(expectedPath, request.Path);
@@ -220,7 +220,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             using (var server = Utilities.CreateHttpServerReturnRoot("/", out root))
             {
                 var responseTask = SendSocketRequestAsync(root, "/" + requestPath);
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 actualPath = context.Request.Path;
                 context.Dispose();
 
@@ -270,7 +270,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             using (var server = Utilities.CreateHttpServerReturnRoot("/", out root))
             {
                 var responseTask = SendSocketRequestAsync(root, requestPath);
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.Equal(expectedPath, context.Request.Path);
                 context.Dispose();
 

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseBodyTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseBodyTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
                 Assert.True(context.AllowSynchronousIO);
 
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var responseTask = SendRequestAsync(address);
 
                 server.Options.AllowSynchronousIO = true;
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Body.Write(new byte[10], 0, 10);
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10);
                 context.Dispose();
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 server.Options.AllowSynchronousIO = true;
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Body.Write(new byte[10], 0, 10);
                 context.Response.Body.Flush();
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10);
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["transfeR-Encoding"] = "CHunked";
                 Stream stream = context.Response.Body;
                 var responseBytes = Encoding.ASCII.GetBytes("10\r\nManually Chunked\r\n0\r\n\r\n");
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var responseTask = SendRequestAsync(address);
 
                 server.Options.AllowSynchronousIO = true;
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["Content-lenGth"] = " 30 ";
                 var stream = context.Response.Body;
                 stream.EndWrite(stream.BeginWrite(new byte[10], 0, 10, null, null));
@@ -160,12 +160,12 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["Content-lenGth"] = " 20 ";
                 context.Dispose();
 #if NET461
                 // HttpClient retries the request because it didn't get a response.
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["Content-lenGth"] = " 20 ";
                 context.Dispose();
 #elif NETCOREAPP2_2
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["Content-lenGth"] = " 20 ";
                 context.Response.Body.Write(new byte[5], 0, 5);
                 context.Dispose();
@@ -201,7 +201,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["Content-lenGth"] = " 10 ";
                 context.Response.Body.Write(new byte[5], 0, 5);
                 Assert.Throws<InvalidOperationException>(() => context.Response.Body.Write(new byte[6], 0, 6));
@@ -220,7 +220,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var responseTask = SendRequestAsync(address);
 
                 server.Options.AllowSynchronousIO = true;
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["Content-lenGth"] = " 10 ";
                 context.Response.Body.Write(new byte[10], 0, 10);
                 Assert.Throws<ObjectDisposedException>(() => context.Response.Body.Write(new byte[6], 0, 6));
@@ -246,7 +246,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var responseTask = SendRequestAsync(address);
 
                 server.Options.AllowSynchronousIO = true;
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Body.Write(new byte[10], 0, 0);
                 Assert.True(context.Response.HasStarted);
                 await context.Response.Body.WriteAsync(new byte[10], 0, 0);
@@ -270,7 +270,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cts = new CancellationTokenSource();
                 // First write sends headers
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
@@ -291,7 +291,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cts = new CancellationTokenSource();
                 cts.CancelAfter(TimeSpan.FromSeconds(10));
                 // First write sends headers
@@ -314,7 +314,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 server.Options.ThrowWriteExceptions = true;
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cts = new CancellationTokenSource();
                 cts.Cancel();
                 // First write sends headers
@@ -323,7 +323,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 context.Dispose();
 #if NET461
                 // HttpClient retries the request because it didn't get a response.
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 cts = new CancellationTokenSource();
                 cts.Cancel();
                 // First write sends headers
@@ -346,7 +346,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cts = new CancellationTokenSource();
                 cts.Cancel();
                 // First write sends headers
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 context.Dispose();
 #if NET461
                 // HttpClient retries the request because it didn't get a response.
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 cts = new CancellationTokenSource();
                 cts.Cancel();
                 // First write sends headers
@@ -379,7 +379,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 server.Options.ThrowWriteExceptions = true;
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cts = new CancellationTokenSource();
                 // First write sends headers
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
@@ -400,7 +400,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cts = new CancellationTokenSource();
                 // First write sends headers
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10, cts.Token);
@@ -424,7 +424,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var cts = new CancellationTokenSource();
                 var responseTask = SendRequestAsync(address, cts.Token);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 // First write sends headers
                 cts.Cancel();
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
@@ -454,7 +454,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var cts = new CancellationTokenSource();
                 var responseTask = SendRequestAsync(address, cts.Token);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
                 // First write sends headers
                 cts.Cancel();
@@ -486,7 +486,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var responseTask = SendRequestAsync(address, cts.Token);
 
                 server.Options.AllowSynchronousIO = true;
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 // First write sends headers
                 cts.Cancel();
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
@@ -509,7 +509,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var cts = new CancellationTokenSource();
                 var responseTask = SendRequestAsync(address, cts.Token);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 // First write sends headers
                 cts.Cancel();
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
@@ -535,7 +535,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 {
                     var responseTask = client.GetAsync(address, HttpCompletionOption.ResponseHeadersRead);
 
-                    context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                    context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                     // First write sends headers
                     context.Response.Body.Write(new byte[10], 0, 10);
 
@@ -569,7 +569,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 {
                     var responseTask = client.GetAsync(address, HttpCompletionOption.ResponseHeadersRead);
 
-                    context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                    context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                     // First write sends headers
                     await context.Response.Body.WriteAsync(new byte[10], 0, 10);
 
@@ -603,7 +603,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 {
                     var responseTask = client.GetAsync(address, HttpCompletionOption.ResponseHeadersRead);
 
-                    context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                    context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                     // First write sends headers
                     context.Response.Body.Write(new byte[10], 0, 10);
 
@@ -633,7 +633,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 {
                     var responseTask = client.GetAsync(address, HttpCompletionOption.ResponseHeadersRead);
 
-                    context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                    context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                     // First write sends headers
                     await context.Response.Body.WriteAsync(new byte[10], 0, 10);
 

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseCachingTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseCachingTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 responseTask = SendRequestAsync(address);
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "2";
                 // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 // Http.sys does not require a content-type to cache on Win7 and Win2008R2
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.Headers["age"] = "12345";
@@ -190,7 +190,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(0);
@@ -203,7 +203,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 responseTask = SendRequestAsync(address);
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "2";
                 // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromMilliseconds(900);
@@ -237,7 +237,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 responseTask = SendRequestAsync(address);
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "2";
                 // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(-10);
@@ -271,7 +271,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 responseTask = SendRequestAsync(address);
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "2";
                 // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -292,7 +292,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.MaxValue;
@@ -319,7 +319,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.ContentLength = 10;
@@ -350,7 +350,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.ContentLength = 10;
@@ -382,7 +382,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var responseTask = SendRequestAsync(address);
 
                 server.Options.AllowSynchronousIO = true;
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -396,7 +396,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 responseTask = SendRequestAsync(address);
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "2";
                 context.Dispose();
 
@@ -415,7 +415,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -430,7 +430,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 responseTask = SendRequestAsync(address);
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "2";
                 context.Dispose();
 
@@ -449,7 +449,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.ContentLength = 10;
@@ -480,7 +480,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -494,7 +494,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 responseTask = SendRequestAsync(address);
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "2";
                 context.Dispose();
 
@@ -513,7 +513,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.ContentLength =_fileLength;
@@ -554,7 +554,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                     var responseTask = SendRequestAsync(address + status);
 
-                    var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                    var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                     context.Response.StatusCode = status;
                     context.Response.Headers["x-request-count"] = status.ToString();
                     context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
@@ -620,7 +620,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address, method);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = context.Request.Method + "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -633,7 +633,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 responseTask = SendRequestAsync(address, method);
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = context.Request.Method + "2";
                 // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -679,7 +679,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 // Cache the first response
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = context.Request.Method + "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -693,7 +693,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 // Try to clear the cache with a second request
                 responseTask = SendRequestAsync(address, method);
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = context.Request.Method + "2";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Dispose();
@@ -724,7 +724,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address, "GET", "x-vary", "vary1");
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.Headers["vary"] = "x-vary";
@@ -755,7 +755,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address, "GET", "Authorization", "Basic abc123");
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -768,7 +768,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 responseTask = SendRequestAsync(address, "GET", "Authorization", "Basic abc123");
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "2";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Dispose();
@@ -789,7 +789,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -802,7 +802,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 responseTask = SendRequestAsync(address, "GET", "Authorization", "Basic abc123");
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "2";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Dispose();
@@ -825,7 +825,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address, "GET", "Pragma", "no-cache");
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -854,7 +854,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -882,7 +882,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address, "GET", "Cache-Control", "no-cache");
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -910,7 +910,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -938,7 +938,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -966,7 +966,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.CacheTtl = TimeSpan.FromSeconds(10);
@@ -993,7 +993,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address, "GET", "Range", "bytes=0-10");
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.StatusCode = 206;
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
@@ -1010,7 +1010,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 responseTask = SendRequestAsync(address, "GET", "Range", "bytes=0-10");
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.StatusCode = 206;
                 context.Response.Headers["x-request-count"] = "2";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
@@ -1037,7 +1037,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.ContentLength = 100;
@@ -1067,7 +1067,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.ContentLength = 100;
@@ -1096,7 +1096,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var responseLength = _fileLength / 2; // Make sure it handles partial files.
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.ContentLength = responseLength;
@@ -1128,7 +1128,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var responseLength = _fileLength / 2; // Make sure it handles partial files.
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["x-request-count"] = "1";
                 context.Response.Headers["content-type"] = "some/thing"; // Http.sys requires a content-type to cache
                 context.Response.ContentLength = responseLength;

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseHeaderTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseHeaderTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Dispose();
 
                 HttpResponseMessage response = await responseTask;
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address, usehttp11: false);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Dispose();
 
                 HttpResponseMessage response = await responseTask;
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendHeadRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Dispose();
 
                 HttpResponseMessage response = await responseTask;
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendHeadRequestAsync(address, usehttp11: false);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Dispose();
 
                 HttpResponseMessage response = await responseTask;
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 // Send a second request to check that the connection wasn't corrupted.
                 responseTask = SendHeadRequestAsync(address);
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Dispose();
                 response = await responseTask;
             }
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendHeadRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.ContentLength = 20;
                 context.Dispose();
 
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 // Send a second request to check that the connection wasn't corrupted.
                 responseTask = SendHeadRequestAsync(address);
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Dispose();
                 response = await responseTask;
             }
@@ -162,7 +162,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.StatusCode = 204; // No Content
                 context.Dispose();
 
@@ -185,7 +185,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendHeadRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.StatusCode = 204; // No Content
                 context.Dispose();
 
@@ -200,7 +200,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 // Send a second request to check that the connection wasn't corrupted.
                 responseTask = SendHeadRequestAsync(address);
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Dispose();
                 response = await responseTask;
             }
@@ -215,7 +215,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 WebRequest request = WebRequest.Create(address);
                 Task<WebResponse> responseTask = request.GetResponseAsync();
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var responseHeaders = context.Response.Headers;
                 responseHeaders["WWW-Authenticate"] = "custom1";
                 context.Dispose();
@@ -240,7 +240,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 WebRequest request = WebRequest.Create(address);
                 Task<WebResponse> responseTask = request.GetResponseAsync();
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var responseHeaders = context.Response.Headers;
                 responseHeaders["WWW-Authenticate"] = new[] { "custom1, and custom2", "custom3" };
                 context.Dispose();
@@ -271,7 +271,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 WebRequest request = WebRequest.Create(address);
                 Task<WebResponse> responseTask = request.GetResponseAsync();
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var responseHeaders = context.Response.Headers;
                 responseHeaders["Custom-Header1"] = new[] { "custom1, and custom2", "custom3" };
                 context.Dispose();
@@ -301,7 +301,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var responseHeaders = context.Response.Headers;
                 responseHeaders["Connection"] = "Close";
                 context.Dispose();
@@ -321,7 +321,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address, usehttp11: false);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Dispose();
 
                 HttpResponseMessage response = await responseTask;
@@ -344,7 +344,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                     request.Version = new Version(1, 0);
                     Task<HttpResponseMessage> responseTask = client.SendAsync(request);
 
-                    var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                    var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                     var responseHeaders = context.Response.Headers;
                     responseHeaders["Transfer-Encoding"] = "chunked";
                     var responseBytes = Encoding.ASCII.GetBytes("10\r\nManually Chunked\r\n0\r\n\r\n");
@@ -372,7 +372,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 // Http.Sys does not support 1.0 keep-alives.
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address, usehttp11: false, sendKeepAlive: true);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Dispose();
 
                 HttpResponseMessage response = await responseTask;
@@ -391,7 +391,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
                 server.Options.AllowSynchronousIO = true;
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var responseHeaders = context.Response.Headers;
 
                 responseHeaders["Custom1"] = new[] { "value1a", "value1b" };
@@ -427,7 +427,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var responseHeaders = context.Response.Headers;
 
                 responseHeaders["Custom1"] = new[] { "value1a", "value1b" };
@@ -481,7 +481,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
                 var responseHeaders = context.Response.Headers;
 

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseSendFileTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseSendFileTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 await Assert.ThrowsAsync<FileNotFoundException>(() =>
                     context.Response.SendFileAsync("Missing.txt", 0, null, CancellationToken.None));
                 context.Dispose();
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
                 context.Dispose();
 
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 await context.Response.SendFileAsync(RelativeFilePath, 0, null, CancellationToken.None);
                 context.Dispose();
 
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
                 context.Dispose();
 
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
                 context.Dispose();
@@ -137,7 +137,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, FileLength / 2, CancellationToken.None);
                 context.Dispose();
 
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
                     () => context.Response.SendFileAsync(AbsoluteFilePath, 1234567, null, CancellationToken.None));
                 context.Dispose();
@@ -176,7 +176,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
                     () => context.Response.SendFileAsync(AbsoluteFilePath, 0, 1234567, CancellationToken.None));
                 context.Dispose();
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, 0, CancellationToken.None);
                 context.Dispose();
 
@@ -219,7 +219,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 await context.Response.SendFileAsync(emptyFilePath, 0, null, CancellationToken.None);
                 Assert.True(context.Response.HasStarted);
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10, CancellationToken.None);
@@ -243,7 +243,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["Content-lenGth"] = FileLength.ToString();
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
 
@@ -265,7 +265,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["Content-lenGth"] = "10";
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, 10, CancellationToken.None);
                 context.Dispose();
@@ -288,7 +288,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.Headers["Content-lenGth"] = "0";
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, 0, CancellationToken.None);
                 context.Dispose();
@@ -311,7 +311,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cts = new CancellationTokenSource();
                 // First write sends headers
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, cts.Token);
@@ -332,7 +332,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cts = new CancellationTokenSource();
                 cts.CancelAfter(TimeSpan.FromSeconds(10));
                 // First write sends headers
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 server.Options.ThrowWriteExceptions = true;
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cts = new CancellationTokenSource();
                 cts.Cancel();
                 // First write sends headers
@@ -364,7 +364,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 context.Dispose();
 #if NET461
                 // .NET HttpClient automatically retries a request if it does not get a response.
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 cts = new CancellationTokenSource();
                 cts.Cancel();
                 // First write sends headers
@@ -387,7 +387,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cts = new CancellationTokenSource();
                 cts.Cancel();
                 // First write sends headers
@@ -396,7 +396,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 context.Dispose();
 #if NET461
                 // .NET HttpClient automatically retries a request if it does not get a response.
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 cts = new CancellationTokenSource();
                 cts.Cancel();
                 // First write sends headers
@@ -420,7 +420,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 server.Options.ThrowWriteExceptions = true;
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cts = new CancellationTokenSource();
                 // First write sends headers
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, cts.Token);
@@ -441,7 +441,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var cts = new CancellationTokenSource();
                 // First write sends headers
                 await context.Response.SendFileAsync(AbsoluteFilePath, 0, null, cts.Token);
@@ -464,7 +464,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var cts = new CancellationTokenSource();
                 var responseTask = SendRequestAsync(address, cts.Token);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
                 // First write sends headers
                 cts.Cancel();
@@ -496,7 +496,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 var cts = new CancellationTokenSource();
                 var responseTask = SendRequestAsync(address, cts.Token);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 // First write sends headers
                 cts.Cancel();
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
@@ -522,7 +522,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 {
                     var responseTask = client.GetAsync(address, HttpCompletionOption.ResponseHeadersRead);
 
-                    context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                    context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                     // First write sends headers
                     var sendFileTask = context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
 
@@ -559,7 +559,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 {
                     var responseTask = client.GetAsync(address, HttpCompletionOption.ResponseHeadersRead);
 
-                    context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                    context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                     // First write sends headers
                     var sendFileTask = context.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
 

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.Equal(200, context.Response.StatusCode);
                 context.Dispose();
 
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.StatusCode = 201;
                 // TODO: env["owin.ResponseProtocol"] = "HTTP/1.0"; // Http.Sys ignores this value
                 context.Dispose();
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.StatusCode = 201;
                 context.Response.ReasonPhrase = "CustomReasonPhrase";
                 // TODO: env["owin.ResponseProtocol"] = "HTTP/1.0"; // Http.Sys ignores this value
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.StatusCode = 901;
                 context.Dispose();
 
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.Throws<ArgumentOutOfRangeException>(() => { context.Response.StatusCode = 100; });
                 context.Dispose();
 
@@ -118,7 +118,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.Throws<ArgumentOutOfRangeException>(() => { context.Response.StatusCode = 0; });
                 context.Dispose();
 

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ServerTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ServerTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Dispose();
 
                 var response = await responseTask;
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 Task<string> responseTask = SendRequestAsync(address);
                 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Response.ContentLength = 11;
                 var writer = new StreamWriter(context.Response.Body);
                 await writer.WriteAsync("Hello World");
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address, "Hello World");
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var input = await new StreamReader(context.Request.Body).ReadToEndAsync();
                 Assert.Equal("Hello World", input);
                 context.Response.ContentLength = 11;
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 {
                     var responseTask = client.GetAsync(address);
 
-                    var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                    var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                     var ct = context.DisconnectToken;
                     Assert.True(ct.CanBeCanceled, "CanBeCanceled");
                     Assert.False(ct.IsCancellationRequested, "IsCancellationRequested");
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 {
                     var responseTask = client.GetAsync(address);
 
-                    var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                    var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
                     client.CancelPendingRequests();
                     await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 {
                     var responseTask = client.GetAsync(address);
 
-                    var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                    var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                     context.Dispose();
 
                     var response = await responseTask;
@@ -176,7 +176,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var ct = context.DisconnectToken;
                 Assert.True(ct.CanBeCanceled, "CanBeCanceled");
                 Assert.False(ct.IsCancellationRequested, "IsCancellationRequested");
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 Assert.True(ct.IsCancellationRequested, "IsCancellationRequested");
 #if NET461
                 // HttpClient re-tries the request because it doesn't know if the request was received.
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Abort();
 #elif NETCOREAPP2_2
 #else
@@ -207,7 +207,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 var ct = context.DisconnectToken;
                 Assert.True(ct.CanBeCanceled, "CanBeCanceled");
                 Assert.False(ct.IsCancellationRequested, "IsCancellationRequested");
@@ -237,7 +237,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 server.Options.RequestQueueLimit = 1001;
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Dispose();
 
                 var response = await responseTask;
@@ -253,7 +253,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 server.Options.Http503Verbosity = Http503VerbosityLevel.Limited;
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 context.Dispose();
 
                 var response = await responseTask;
@@ -269,7 +269,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.Equal(string.Empty, context.Request.PathBase);
                 Assert.Equal("/", context.Request.Path);
                 context.Dispose();
@@ -282,7 +282,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 responseTask = SendRequestAsync(address);
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.Equal("/pathbase", context.Request.PathBase);
                 Assert.Equal("/", context.Request.Path);
                 context.Dispose();
@@ -302,7 +302,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
                 server.Options.UrlPrefixes.Add(address);
                 var responseTask = SendRequestAsync(address);
 
-                var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.Equal("/pathbase", context.Request.PathBase);
                 Assert.Equal("/", context.Request.Path);
                 context.Dispose();
@@ -314,7 +314,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
 
                 responseTask = SendRequestAsync(address);
 
-                context = await server.AcceptAsync(Utilities.DefaultTimeout);
+                context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
                 Assert.Equal(string.Empty, context.Request.PathBase);
                 Assert.Equal("/pathbase/", context.Request.Path);
                 context.Dispose();

--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/Utilities.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/Utilities.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.HttpSys.Listener
@@ -106,6 +105,22 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 server.Dispose();
                 throw new TimeoutException("AcceptAsync has timed out.");
+            }
+        }
+
+        // Fail if the given response task completes before the given accept task.
+        internal static async Task<RequestContext> Before<T>(this Task<RequestContext> acceptTask, Task<T> responseTask)
+        {
+            var completedTask = await Task.WhenAny(acceptTask, responseTask);
+
+            if (completedTask == acceptTask)
+            {
+                return await acceptTask;
+            }
+            else
+            {
+                var response = await responseTask;
+                throw new InvalidOperationException("The response completed prematurely: " + response.ToString());
             }
         }
     }


### PR DESCRIPTION
#457 This series of tests runs the client and server inline asynchronously. Some of them have been flaky and we added timeouts to prevent them from hanging. However that timeout doesn't explain why it failed. One theory is that the client encountered an error before the request reached the server, but we time out before we await that task so the error goes unreported.

I've added an extension that surfaces the error details if the request fails before the server receives it. 

/cc: @ryanbrandenburg 