### PR TITLE
Show HTTP/2 status on requests

### DIFF
--- a/shared/Microsoft.AspNetCore.HttpSys.Sources/Constants.cs
+++ b/shared/Microsoft.AspNetCore.HttpSys.Sources/Constants.cs
@@ -17,5 +17,6 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         internal static Version V1_0 = new Version(1, 0);
         internal static Version V1_1 = new Version(1, 1);
+        internal static Version V2 = new Version(2, 0);
     }
 }

--- a/shared/Microsoft.AspNetCore.HttpSys.Sources/NativeInterop/HttpApiTypes.cs
+++ b/shared/Microsoft.AspNetCore.HttpSys.Sources/NativeInterop/HttpApiTypes.cs
@@ -434,10 +434,19 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             internal HTTP_REQUEST_AUTH_INFO* pInfo;
         }
 
+        [Flags]
+        internal enum HTTP_REQUEST_FLAGS
+        {
+            None = 0,
+            MoreEntityBodyExists = 1,
+            IPRouted = 2,
+            Http2 = 4,
+        }
+
         [StructLayout(LayoutKind.Sequential)]
         internal struct HTTP_REQUEST
         {
-            internal uint Flags;
+            internal HTTP_REQUEST_FLAGS Flags;
             internal ulong ConnectionId;
             internal ulong RequestId;
             internal ulong UrlContext;

--- a/shared/Microsoft.AspNetCore.HttpSys.Sources/RequestProcessing/NativeRequestContext.cs
+++ b/shared/Microsoft.AspNetCore.HttpSys.Sources/RequestProcessing/NativeRequestContext.cs
@@ -88,6 +88,8 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             }
         }
 
+        internal bool IsHttp2 => NativeRequest->Flags.HasFlag(HttpApiTypes.HTTP_REQUEST_FLAGS.Http2);
+
         internal uint Size
         {
             get { return (uint)_backingBuffer.Length - AlignmentPadding; }
@@ -156,6 +158,10 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         internal Version GetVersion()
         {
+            if (IsHttp2)
+            {
+                return Constants.V2;
+            }
             var major = NativeRequest->Version.MajorVersion;
             var minor = NativeRequest->Version.MinorVersion;
             if (major == 1 && minor == 1)

--- a/src/Microsoft.AspNetCore.Server.HttpSys/FeatureContext.cs
+++ b/src/Microsoft.AspNetCore.Server.HttpSys/FeatureContext.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Features.Authentication;
+using Microsoft.AspNetCore.HttpSys.Internal;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Server.HttpSys
@@ -168,11 +169,15 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 if (IsNotInitialized(Fields.Protocol))
                 {
                     var protocol = Request.ProtocolVersion;
-                    if (protocol.Major == 1 && protocol.Minor == 1)
+                    if (protocol == Constants.V2)
+                    {
+                        _httpProtocolVersion = "HTTP/2";
+                    }
+                    else if (protocol == Constants.V1_1)
                     {
                         _httpProtocolVersion = "HTTP/1.1";
                     }
-                    else if (protocol.Major == 1 && protocol.Minor == 0)
+                    else if (protocol == Constants.V1_0)
                     {
                         _httpProtocolVersion = "HTTP/1.0";
                     }


### PR DESCRIPTION
This is the small part of #106 where we surface "HTTP/2" in Request.Protocol. ANCM in-proc will need a similar change.

Push promise is not happening until some future milestone.