### PR TITLE
Disable flaky test on Win7/Win2008

### DIFF
--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseCachingTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Listener/ResponseCachingTests.cs
@@ -537,6 +537,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         }
 
         [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2, SkipReason = "Managed Socket or SocketHttpHandler issue: https://github.com/dotnet/corefx/issues/30691")]
         public async Task Caching_SetTtlAndStatusCode_Cached()
         {
             string address;


### PR DESCRIPTION
Addresses https://github.com/aspnet/HttpSysServer/issues/468. This test is only flaky on Win7 and Win2008 and it looks like it's failing inside HttpClient. I don't think it's worth the time to rewrite the test to be more robust. I think it's sufficient to disable these test on the older systems and keep them running on everything Win8 and newer.