### PR TITLE
Re-enable skipped auth test

### DIFF
--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/AuthenticationTests.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/AuthenticationTests.cs
@@ -346,7 +346,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
-        [ConditionalTheory(Skip = "https://github.com/aspnet/HttpSysServer/issues/474")]
+        [ConditionalTheory]
         [InlineData(AuthenticationSchemes.Negotiate)]
         [InlineData(AuthenticationSchemes.NTLM)]
         // [InlineData(AuthenticationSchemes.Digest)] // Not implemented


### PR DESCRIPTION
 #474 CoreFx has fixed the regression.