### PR TITLE
Cleanup server limits tests

### DIFF
--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Utilities.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Utilities.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         private const int MaxPort = 8000;
         private static int NextPort = BasePort;
         private static object PortLock = new object();
+        internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(15);
 
         internal static IServer CreateHttpServer(out string baseAddress, RequestDelegate app)
         {
@@ -59,6 +60,11 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 options.Authentication.Schemes = authType;
                 options.Authentication.AllowAnonymous = allowAnonymous;
             }, app);
+        }
+
+        internal static IWebHost CreateDynamicHost(out string baseAddress, Action<HttpSysOptions> configureOptions, RequestDelegate app)
+        {
+            return CreateDynamicHost(string.Empty, out var root, out baseAddress, configureOptions, app);
         }
 
         internal static IWebHost CreateDynamicHost(string basePath, out string root, out string baseAddress, Action<HttpSysOptions> configureOptions, RequestDelegate app)


### PR DESCRIPTION
 #472 #476 #469 These tests have had a few sporadic failures that we can't reproduce. This is some test cleanup that could help avoid races by not creating two server instances per test.